### PR TITLE
[FEAT] ServerProfileController 개발 및 health check 의존성 추가

### DIFF
--- a/nonsoolmateServer/build.gradle
+++ b/nonsoolmateServer/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	// validate
 	implementation 'org.hibernate.validator:hibernate-validator'
 
+	// Health Check
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/common/profile/ServerProfileController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/common/profile/ServerProfileController.java
@@ -5,8 +5,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Arrays;
-
 @RestController
 @RequiredArgsConstructor
 public class ServerProfileController {
@@ -15,8 +13,6 @@ public class ServerProfileController {
 
     @GetMapping("/profile")
     public String getProfile() {
-        return Arrays.stream(env.getActiveProfiles())
-                .findFirst()
-                .orElse("");
+        return env.getActiveProfiles()[0];
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/common/profile/ServerProfileController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/common/profile/ServerProfileController.java
@@ -1,0 +1,22 @@
+package com.nonsoolmate.nonsoolmateServer.common.profile;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+
+@RestController
+@RequiredArgsConstructor
+public class ServerProfileController {
+
+    private final Environment env;
+
+    @GetMapping("/profile")
+    public String getProfile() {
+        return Arrays.stream(env.getActiveProfiles())
+                .findFirst()
+                .orElse("");
+    }
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#3 -> dev
- closed #3

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- ServerProfileController 개발
- actuator/health에 대한 의존성 추가

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- localhost:8080/actuator/health
<img width="864" alt="image" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/47571e08-d8fa-4d0f-a5bf-ae10648e0f75">
- localhost:8080/profile
<img width="866" alt="image" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/0384ad9c-18ad-4362-a0e3-37244fed519c">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 프로필 서버 관련 controller common.profile 안에 넣었는데 괜찮으신지 궁금합니다!