### PR TITLE
[FEAT] 문제이미지 및 해제PDF 조회 API 개발

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
@@ -1,5 +1,8 @@
 package com.nonsoolmate.nonsoolmateServer.domain.university.controller;
 
+import static com.nonsoolmate.nonsoolmateServer.domain.university.exception.UniversityExamSuccessType.GET_UNIVERSITY_EXAM_IMAGE_AND_ANSWER_SUCCESS;
+
+import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.UniversityExamImageAndAnswerResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.UniversityExamImageResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.UniversityExamInfoResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.exception.UniversityExamSuccessType;
@@ -36,5 +39,14 @@ public class UniversityExamController {
         Page<UniversityExamImageResponseDTO> images = universityExamService.getUniversityExamImages(id, pageRequest);
         return ResponseEntity.ok()
                 .body(ApiResponse.success(UniversityExamSuccessType.GET_UNIVERSITY_EXAM_IMAGE_SUCCESS, images));
+    }
+
+
+    @GetMapping("{id}/answer")
+    public ResponseEntity<ApiResponse<UniversityExamImageAndAnswerResponseDTO>> getUniversityExamImageAndAnswer(
+            @PathVariable("id") Long universityExamId
+    ) {
+        return ResponseEntity.ok().body(ApiResponse.success(GET_UNIVERSITY_EXAM_IMAGE_AND_ANSWER_SUCCESS,
+                universityExamService.getUniversityExamImageAndAnswer(universityExamId)));
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/UniversityExamImageAndAnswerResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/UniversityExamImageAndAnswerResponseDTO.java
@@ -1,0 +1,14 @@
+package com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto;
+
+import java.util.List;
+
+public record UniversityExamImageAndAnswerResponseDTO(
+        String university, String college, List<UniversityExamImageResponseDTO> examQuestionList, String examAnswerUrl
+) {
+    static public UniversityExamImageAndAnswerResponseDTO of(String university, String college,
+                                                             List<UniversityExamImageResponseDTO> examQuestionList,
+                                                             String examAnswerUrl) {
+        return new UniversityExamImageAndAnswerResponseDTO(university, college, examQuestionList, examAnswerUrl);
+    }
+}
+

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/entity/UniversityExamImage.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/entity/UniversityExamImage.java
@@ -26,5 +26,5 @@ public class UniversityExamImage {
     private UniversityExam universityExam;
 
     @NotNull
-    private String universityExamImageUrl;
+    private String universityExamImageFileName;
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/exception/UniversityExamExceptionType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/exception/UniversityExamExceptionType.java
@@ -11,7 +11,8 @@ public enum UniversityExamExceptionType implements BusinessExceptionType {
     /**
      * 404 Not Found
      */
-    NOT_FOUND_UNIVERSITY_EXAM(HttpStatus.NOT_FOUND, "존재하지 않는 대학 시험입니다.");
+    NOT_FOUND_UNIVERSITY_EXAM(HttpStatus.NOT_FOUND, "존재하지 않는 대학 시험입니다."),
+    NOT_FOUND_UNIVERSITY_EXAM_IMAGE(HttpStatus.NOT_FOUND, "존재하지 않는 대학 시험 입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/exception/UniversityExamSuccessType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/exception/UniversityExamSuccessType.java
@@ -11,7 +11,9 @@ public enum UniversityExamSuccessType implements BusinessSucessType {
      * 200 OK
      */
     GET_UNIVERSITY_EXAM_SUCCESS(HttpStatus.OK, "대학 조회에 성공했습니다"),
-    GET_UNIVERSITY_EXAM_IMAGE_SUCCESS(HttpStatus.OK, "대학 시험 이미지 조회에 성공했습니다");
+    GET_UNIVERSITY_EXAM_IMAGE_SUCCESS(HttpStatus.OK, "대학 시험 이미지 조회에 성공했습니다"),
+    GET_UNIVERSITY_EXAM_IMAGE_AND_ANSWER_SUCCESS(HttpStatus.OK, "대학 시험 이미지 및 해제 PDF 조회에 성공했습니다");
+
 
     private final HttpStatus status;
     private final String message;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/repository/UniversityExamImageRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/repository/UniversityExamImageRepository.java
@@ -2,10 +2,15 @@ package com.nonsoolmate.nonsoolmateServer.domain.university.repository;
 
 import com.nonsoolmate.nonsoolmateServer.domain.university.entity.UniversityExam;
 import com.nonsoolmate.nonsoolmateServer.domain.university.entity.UniversityExamImage;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UniversityExamImageRepository extends JpaRepository<UniversityExamImage, Long> {
     Page<UniversityExamImage> findAllByUniversityExam(UniversityExam universityExam, Pageable pageable);
+
+    List<UniversityExamImage> findAllByUniversityExam(UniversityExam universityExam);
+
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/service/UniversityExamService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/service/UniversityExamService.java
@@ -1,5 +1,6 @@
 package com.nonsoolmate.nonsoolmateServer.domain.university.service;
 
+import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.UniversityExamImageAndAnswerResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.UniversityExamImageResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.UniversityExamInfoResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.entity.UniversityExam;
@@ -7,6 +8,9 @@ import com.nonsoolmate.nonsoolmateServer.domain.university.entity.UniversityExam
 import com.nonsoolmate.nonsoolmateServer.domain.university.exception.UniversityExamException;
 import com.nonsoolmate.nonsoolmateServer.domain.university.exception.UniversityExamExceptionType;
 import com.nonsoolmate.nonsoolmateServer.domain.university.repository.UniversityExamImageRepository;
+import com.nonsoolmate.nonsoolmateServer.external.aws.service.S3Service;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,8 +22,14 @@ import com.nonsoolmate.nonsoolmateServer.domain.university.repository.University
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UniversityExamService {
+    private static final String EXAM_ANSWER_PATH = "exam-answer/";
+    private static final String EXAM_IMAGE_PATH = "exam-image/";
+
+
     private final UniversityExamRepository universityExamRepository;
     private final UniversityExamImageRepository universityExamImageRepository;
+    private final S3Service s3Service;
+
 
     public UniversityExamInfoResponseDTO getUniversityExam(Long universityExamId) {
         UniversityExam universityExam = universityExamRepository.findByUniversityExamId(universityExamId)
@@ -36,7 +46,33 @@ public class UniversityExamService {
         Page<UniversityExamImage> universityExamImages = universityExamImageRepository.findAllByUniversityExam(
                 universityExam,
                 pageable);
-        return universityExamImages.map(image -> UniversityExamImageResponseDTO.of(image.getUniversityExamImageUrl()));
+        return universityExamImages.map(
+                image -> UniversityExamImageResponseDTO.of(image.getUniversityExamImageFileName()));
+    }
+
+    public UniversityExamImageAndAnswerResponseDTO getUniversityExamImageAndAnswer(Long universityExamId) {
+        UniversityExam universityExam = universityExamRepository.findByUniversityExamId(universityExamId)
+                .orElseThrow(() -> new UniversityExamException(
+                        UniversityExamExceptionType.NOT_FOUND_UNIVERSITY_EXAM));
+
+        String examAnswerUrl = s3Service.createPresignedGetUrl(EXAM_ANSWER_PATH,
+                universityExam.getExamAnswerFileName());
+        List<UniversityExamImageResponseDTO> examImageUrls = new ArrayList<>();
+
+        List<UniversityExamImage> UniversityExamImages = universityExamImageRepository.findAllByUniversityExam(
+                universityExam);
+
+        UniversityExamImages.stream().forEach(universityExamImage -> {
+            String presignedGetUrl = s3Service.createPresignedGetUrl(EXAM_IMAGE_PATH,
+                    universityExamImage.getUniversityExamImageFileName());
+
+            examImageUrls.add(
+                    UniversityExamImageResponseDTO.of(presignedGetUrl));
+        });
+
+        return UniversityExamImageAndAnswerResponseDTO.of(
+                universityExam.getUniversity().getUniversityName(),
+                universityExam.getUniversity().getUniversityCollege(), examImageUrls, examAnswerUrl);
     }
 
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#38 -> dev
- closed #38

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 문제 이미지 및 해제 PDF 조회하는 API 개발 했습니다!

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="875" alt="스크린샷 2024-01-11 오전 2 03 25" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/100754581/934cc553-cb3f-402e-a872-7375d01abeaf">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
