### PR TITLE
[FEAT] 첨삭 PDF 저장 API 구현

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/UniversityExamRecordController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/UniversityExamRecordController.java
@@ -1,9 +1,11 @@
 package com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller;
 
+import static com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.exception.UniversityExamRecordSuccessType.GET_UNIVERSITY_EXAM_RECORD_RESULT_SUCCESS;
 import static com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.exception.UniversityExamRecordSuccessType.GET_UNIVERSITY_EXAM_RECORD_SUCCESS;
 
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
 import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller.dto.UniversityExamRecordResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller.dto.UniversityExamRecordResultResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.service.UniversityExamRecordService;
 import com.nonsoolmate.nonsoolmateServer.global.response.ApiResponse;
 import com.nonsoolmate.nonsoolmateServer.global.security.AuthUser;
@@ -28,5 +30,14 @@ public class UniversityExamRecordController {
     ) {
         return ResponseEntity.ok().body(ApiResponse.success(GET_UNIVERSITY_EXAM_RECORD_SUCCESS,
                 universityExamRecordService.getUniversityExamRecord(universityExamId, member)));
+    }
+
+    @GetMapping("/result/{id}")
+    public ResponseEntity<ApiResponse<UniversityExamRecordResultResponseDTO>> getUniversityExamRecordResult(
+            @PathVariable("id") Long universityExamId,
+            @AuthUser Member member
+    ){
+        return ResponseEntity.ok().body(ApiResponse.success(GET_UNIVERSITY_EXAM_RECORD_RESULT_SUCCESS,
+                universityExamRecordService.getUniversityExamRecordResult(universityExamId, member)));
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/dto/UniversityExamRecordResultResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/dto/UniversityExamRecordResultResponseDTO.java
@@ -1,0 +1,9 @@
+package com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller.dto;
+
+public record UniversityExamRecordResultResponseDTO(
+        String examResultUrl
+) {
+    public static UniversityExamRecordResultResponseDTO of(String examResultUrl){
+        return new UniversityExamRecordResultResponseDTO(examResultUrl);
+    }
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/exception/UniversityExamRecordSuccessType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/exception/UniversityExamRecordSuccessType.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum UniversityExamRecordSuccessType implements BusinessSucessType {
-    GET_UNIVERSITY_EXAM_RECORD_SUCCESS(HttpStatus.OK, "첨삭 PDF, 해제 PDF 조회에 성공했습니다.");
+    GET_UNIVERSITY_EXAM_RECORD_SUCCESS(HttpStatus.OK, "첨삭 PDF, 해제 PDF 조회에 성공했습니다."),
+    GET_UNIVERSITY_EXAM_RECORD_RESULT_SUCCESS(HttpStatus.OK, "첨삭 PDF 조회에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/service/UniversityExamRecordService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/service/UniversityExamRecordService.java
@@ -9,6 +9,7 @@ import com.nonsoolmate.nonsoolmateServer.domain.university.entity.UniversityExam
 import com.nonsoolmate.nonsoolmateServer.domain.university.exception.UniversityExamException;
 import com.nonsoolmate.nonsoolmateServer.domain.university.repository.UniversityExamRepository;
 import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller.dto.UniversityExamRecordResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller.dto.UniversityExamRecordResultResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.entity.UniversityExamRecord;
 import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.repository.UniversityExamRecordRepository;
 import com.nonsoolmate.nonsoolmateServer.external.aws.service.CloudFrontService;
@@ -38,6 +39,20 @@ public class UniversityExamRecordService {
                 universityExamRecord.getExamRecordResultFileName());
 
         return UniversityExamRecordResponseDTO.of(answerUrl, resultUrl);
+    }
+
+    public UniversityExamRecordResultResponseDTO getUniversityExamRecordResult(Long universityExamId, Member member) {
+
+        UniversityExam universityExam = universityExamRepository.findByUniversityExamId(universityExamId)
+                .orElseThrow(() -> new UniversityExamException(NOT_FOUND_UNIVERSITY_EXAM));
+
+        UniversityExamRecord universityExamRecord = universityExamRecordRepository.findByUniversityExamAndMemberOrElseThrowException(
+                universityExam, member);
+
+        String resultUrl = cloudFrontService.createPreSignedGetUrl(EXAM_RESULT_FOLDER_NAME,
+                universityExamRecord.getExamRecordResultFileName());
+
+        return UniversityExamRecordResultResponseDTO.of(resultUrl);
     }
 
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#39 -> dev
- closed #39 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 첨삭 PDF 저장 API 구현

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="839" alt="스크린샷 2024-01-11 오후 8 22 22" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/100754581/074613f4-d2c7-4e13-aab6-03b7f1651262">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
