### PR TITLE
[FIX] 최신 sdk 사용에 따른 cloudFrontService 및 S3Service validateURL 로직, 에러핸들링 수정

### DIFF
--- a/nonsoolmateServer/build.gradle
+++ b/nonsoolmateServer/build.gradle
@@ -48,11 +48,7 @@ dependencies {
     // AWS sdk
     implementation("software.amazon.awssdk:bom:2.21.0")
     implementation("software.amazon.awssdk:s3:2.21.0")
-    compileOnly group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.534'
-    implementation 'software.amazon.awssdk:cloudfront:2.18.26' // AWS SDK for Java v2의 버전
-
-    compileOnly group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.1.RELEASE'
-
+    implementation 'software.amazon.awssdk:cloudfront:2.22.3'
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/service/UniversityExamService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/service/UniversityExamService.java
@@ -55,7 +55,7 @@ public class UniversityExamService {
                         UniversityExamExceptionType.NOT_FOUND_UNIVERSITY_EXAM));
 
         String examAnswerUrl = cloudFrontService.createPreSignedGetUrl(EXAM_ANSWER_FOLDER_NAME,
-                universityExam.getExamAnswerFileName());
+                universityExam.getExamAnswerFileName(), universityExam.getExamTimeLimit());
         List<UniversityExamImageResponseDTO> examImageUrls = new ArrayList<>();
 
         List<UniversityExamImage> UniversityExamImages = universityExamImageRepository.findAllByUniversityExam(
@@ -63,7 +63,7 @@ public class UniversityExamService {
 
         UniversityExamImages.stream().forEach(universityExamImage -> {
             String presignedGetUrl = cloudFrontService.createPreSignedGetUrl(EXAM_RESULT_FOLDER_NAME,
-                    universityExamImage.getUniversityExamImageFileName());
+                    universityExamImage.getUniversityExamImageFileName(), universityExam.getExamTimeLimit());
 
             examImageUrls.add(
                     UniversityExamImageResponseDTO.of(presignedGetUrl));

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/service/UniversityExamRecordService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/service/UniversityExamRecordService.java
@@ -39,9 +39,9 @@ public class UniversityExamRecordService {
         UniversityExamRecord universityExamRecord = getUniversityExamByUniversityExamAndMember(universityExam, member);
 
         String answerUrl = cloudFrontService.createPreSignedGetUrl(EXAM_ANSWER_FOLDER_NAME,
-                universityExam.getExamAnswerFileName());
+                universityExam.getExamAnswerFileName(), universityExam.getExamTimeLimit());
         String resultUrl = cloudFrontService.createPreSignedGetUrl(EXAM_RESULT_FOLDER_NAME,
-                universityExamRecord.getExamRecordResultFileName());
+                universityExamRecord.getExamRecordResultFileName(), universityExam.getExamTimeLimit());
 
         return UniversityExamRecordResponseDTO.of(answerUrl, resultUrl);
     }
@@ -52,7 +52,7 @@ public class UniversityExamRecordService {
         UniversityExamRecord universityExamRecord = getUniversityExamByUniversityExamAndMember(universityExam, member);
 
         String resultUrl = cloudFrontService.createPreSignedGetUrl(EXAM_RESULT_FOLDER_NAME,
-                universityExamRecord.getExamRecordResultFileName());
+                universityExamRecord.getExamRecordResultFileName(), universityExam.getExamTimeLimit());
 
         return UniversityExamRecordResultResponseDTO.of(resultUrl);
     }
@@ -61,8 +61,8 @@ public class UniversityExamRecordService {
     public UniversityExamRecordIdResponse createUniversityExamRecord(
             CreateUniversityExamRequestDTO request, Member member) {
         UniversityExam universityExam = getUniversityExam(request.universityExamId());
+        String fileName = s3Service.validateURL(EXAM_SHEET_FOLDER_NAME, request.memberSheetFileName());
         try {
-            String fileName = s3Service.validateURL(EXAM_SHEET_FOLDER_NAME, request.memberSheetFileName());
             UniversityExamRecord universityexamRecord = createUniversityExamRecord(universityExam, member,
                     request.memberTakeTimeExam(),
                     fileName);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/aws/error/AWSExceptionType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/aws/error/AWSExceptionType.java
@@ -8,10 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum AWSExceptionType implements BusinessExceptionType {
     DELETE_FILE_AWS_S3_FAIL(HttpStatus.BAD_REQUEST, "S3 파일 삭제에 실패했습니다"),
-    NOT_FOUND_FILE_AWS_S3(HttpStatus.BAD_REQUEST, "S3에서 파일을 찾을 수 없습니다"),
-    GET_PRESIGNED_URL_AWS_CLOUDFRONT_FAIL(HttpStatus.BAD_REQUEST, "Cloud PresignedUrl 발급에 실패했습니다"),
-    NOT_FOUND_CLOUD_PRIVATE_KEY_FAIL(HttpStatus.NOT_FOUND, "Cloud Private Key 조회에 실패했습니다"),
-    INVALID_KEY_SPEC_FAIL(HttpStatus.BAD_REQUEST, "Cloud Private Key Spec이 잘못되었습니다");
+    NOT_FOUND_FILE_AWS_S3(HttpStatus.NOT_FOUND, "S3에서 파일을 찾을 수 없습니다"),
+    GET_PRESIGNED_URL_AWS_CLOUDFRONT_FAIL(HttpStatus.BAD_REQUEST, "Cloud PresignedUrl 발급에 실패했습니다");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/#56 -> dev
- closed #56

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- cloudFrontService에서 사용하는 라이브러리의 버전을  `implementation 'software.amazon.awssdk:cloudfront:2.22.3'`으로 변경하고 관련 코드를 수정했습니다
  - 코드 수정은 다음 공식 문서를 참고했습니다
    -  https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/cloudfront/model/CannedSignerRequest.Builder.html
    - https://aws.amazon.com/ko/blogs/developer/amazon-cloudfront-signed-urls-and-cookies-are-now-supported-in-aws-sdk-for-java-2-x/
- S3Service 내 validateURL 로직 부분을 수정하고, 파일이 존재하지 않을 경우 CustomException이 반환 되도록 했습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- cloudFront 코드 수정에 따른 동작 확인
<img width="780" alt="스크린샷 2024-01-12 오전 10 04 30" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/7ef2f3b9-9c86-47f0-8d2f-991e22eca55d">

- validateURL 에러 확인
<img width="783" alt="스크린샷 2024-01-12 오전 10 26 11" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/a3d8d720-6f41-4808-9bd2-2cf37bab293c">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 각 API 별로 pdf, 이미지를 몇 분 동안 조회 가능하게 할지 ExpiredTime을 다르게 설정하면 좋을 것 같은데 어떠신가요? 현재 로직에서는 일단 UniversityExam의 제한 시간으로 모두 설정해두었습니다!
