### PR TITLE
[FEAT] 시험 기록 API에서 사용자 첨삭권 감소 로직 개발

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Member.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Member.java
@@ -2,6 +2,8 @@ package com.nonsoolmate.nonsoolmateServer.domain.member.entity;
 
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.enums.PlatformType;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.enums.Role;
+import com.nonsoolmate.nonsoolmateServer.domain.member.exception.MemberException;
+import com.nonsoolmate.nonsoolmateServer.domain.member.exception.MemberExceptionType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -62,5 +64,12 @@ public class Member {
         this.birthYear = birthYear;
         this.gender = gender;
         this.phoneNumber = phoneNumber;
+    }
+
+    public void decreaseTicket() {
+        if (this.ticketCount <= 0) {
+            throw new MemberException(MemberExceptionType.MEMBER_USE_TICKET_FAIL);
+        }
+        this.ticketCount -= 1;
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/exception/MemberExceptionType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/exception/MemberExceptionType.java
@@ -11,7 +11,8 @@ public enum MemberExceptionType implements BusinessExceptionType {
     /**
      * 404 Not Found
      */
-    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다.");
+    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+    MEMBER_USE_TICKET_FAIL(HttpStatus.BAD_REQUEST, "티켓 사용에 실패했습니다. 티켓이 부족합니다");
 
     private final HttpStatus status;
     private final String message;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/aws/FolderName.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/aws/FolderName.java
@@ -1,9 +1,6 @@
 package com.nonsoolmate.nonsoolmateServer.external.aws;
 
-import lombok.Getter;
-
-@Getter
-public class FolderName {
+public abstract class FolderName {
     public static final String EXAM_ANSWER_FOLDER_NAME = "exam-answer/";
     public static final String EXAM_RESULT_FOLDER_NAME = "exam-result/";
     public static final String EXAM_SHEET_FOLDER_NAME = "exam-sheet/";


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#58 -> dev
- closed #58 


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 시험 기록 API를 호출할 시 시험 기록이 완료되면 사용자의 첨삭권이 동시에 감소하도록 로직을 추가했습니다
- UniversityExamRecordService 내 createUniversityExamRecord() 함수에서의 에러 처리를 수정했습니다


## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 티켓 감소 확인: 생성된 시험 기록 2번에 대한 결과를 함께 첨부합니다
<img width="1193" alt="image" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/ad1bf63e-7040-48cb-b254-74f42fbf2516">

- 사용자의 티켓이 부족할 때
<img width="627" alt="스크린샷 2024-01-12 오후 3 03 41" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/6cc5a354-d639-4002-819c-4887a29bce20">
- 파일 이름이 잘못되었을 때
<img width="636" alt="스크린샷 2024-01-12 오후 3 04 16" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/03f8dea7-e8c8-4190-a635-00cc615a87ba">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 일단 member 엔티티에서 티켓 감소 함수를 만들었는데 어떻게 생각하시는지 궁금합니다!
