### PR TITLE
[FEAT] 대학 시험 문제 리스트 조회 API 정렬 구현

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/service/SelectUniversityService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/service/SelectUniversityService.java
@@ -32,7 +32,8 @@ public class SelectUniversityService {
 
 
     public List<SelectUniversityResponseDTO> getSelectUniversities(Member member) {
-        List<SelectUniversity> selectUniversities = selectUniversityRepository.findAllByMemberOrderByUniversityNameASCUniversityCollegeAsc(member);
+        List<SelectUniversity> selectUniversities = selectUniversityRepository.findAllByMemberOrderByUniversityNameASCUniversityCollegeAsc(
+                member);
         List<SelectUniversityResponseDTO> selectUniversityResponseDTOS = new ArrayList<>();
 
         selectUniversities.stream().forEach(selectUniversity -> {
@@ -40,11 +41,11 @@ public class SelectUniversityService {
 
             University university = universityRepository.findByUniversityId(
                     selectUniversity.getUniversity().getUniversityId()).orElse(null);
-            if(university == null){
+            if (university == null) {
                 status = false;
             }
             selectUniversityResponseDTOS.add(SelectUniversityResponseDTO.of(university.getUniversityId(),
-                    university.getUniversityName(),university.getUniversityCollege(),
+                    university.getUniversityName(), university.getUniversityCollege(),
                     status));
 
         });
@@ -54,7 +55,8 @@ public class SelectUniversityService {
 
     public List<SelectUniversityExamsResponseDTO> getSelectUniversityExams(Member member) {
         List<SelectUniversityExamsResponseDTO> selectUniversityExamsResponseDTOS = new ArrayList<>();
-        List<SelectUniversity> selectUniversities = selectUniversityRepository.findAllByMemberOrderByUniversityNameASCUniversityCollegeAsc(member);
+        List<SelectUniversity> selectUniversities = selectUniversityRepository.findAllByMemberOrderByUniversityNameASCUniversityCollegeAsc(
+                member);
 
         for (SelectUniversity selectUniversity : selectUniversities) {
             selectUniversityExamsResponseDTOS.add(getSelectUniversityExamsResponseDTO(selectUniversity, member));
@@ -88,7 +90,8 @@ public class SelectUniversityService {
                     universityExamRecord == null ? BEFORE_EXAM : universityExamRecord.getExamResultStatus().getStatus();
             selectUniversityExamResponseDTOS.add(
                     SelectUniversityExamResponseDTO.of(universityExam.getUniversityExamId(),
-                            universityExam.getExamName(), universityExam.getExamTimeLimit(), status));
+                            universityExam.getUniversityExamName(), universityExam.getUniversityExamTimeLimit(),
+                            status));
         }
         return selectUniversityExamResponseDTOS;
     }
@@ -105,14 +108,17 @@ public class SelectUniversityService {
         Map<Long, University> universityMap = new HashMap<>();
 
         curUniversityIds.stream().forEach(curUniversityId -> {
-            universityMap.put(curUniversityId, universityRepository.findByUniversityIdOrElseThrowException(curUniversityId));
+            universityMap.put(curUniversityId,
+                    universityRepository.findByUniversityIdOrElseThrowException(curUniversityId));
 
             boolean isPresent = false;
-            for(Long prevUniversityId : prevUniversityIds){
-                if(prevUniversityId == curUniversityId) isPresent = true;
+            for (Long prevUniversityId : prevUniversityIds) {
+                if (prevUniversityId == curUniversityId) {
+                    isPresent = true;
+                }
             }
 
-            if(!isPresent){
+            if (!isPresent) {
                 selectUniversityRepository.save(SelectUniversity
                         .builder()
                         .member(member)
@@ -121,15 +127,18 @@ public class SelectUniversityService {
             }
         });
 
-        prevUniversityIds.stream().forEach(prevUniversityId ->{
-            universityMap.put(prevUniversityId, universityRepository.findByUniversityIdOrElseThrowException(prevUniversityId));
+        prevUniversityIds.stream().forEach(prevUniversityId -> {
+            universityMap.put(prevUniversityId,
+                    universityRepository.findByUniversityIdOrElseThrowException(prevUniversityId));
 
             boolean isPresent = false;
-            for(Long curUniversityId : curUniversityIds){
-                if(prevUniversityId == curUniversityId) isPresent = true;
+            for (Long curUniversityId : curUniversityIds) {
+                if (prevUniversityId == curUniversityId) {
+                    isPresent = true;
+                }
             }
 
-            if(!isPresent){
+            if (!isPresent) {
                 selectUniversityRepository.deleteByMemberAndUniversity(member, universityMap.get(prevUniversityId));
             }
         });

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/service/SelectUniversityService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/service/SelectUniversityService.java
@@ -69,7 +69,7 @@ public class SelectUniversityService {
                                                                                  Member member) {
         List<SelectUniversityExamResponseDTO> selectUniversityExamResponseDTOS;
 
-        List<UniversityExam> universityExams = universityExamRepository.findAllByUniversity(
+        List<UniversityExam> universityExams = universityExamRepository.findAllByUniversityOrderByUniversityExamYearDescUniversityExamNameAsc(
                 selectUniversity.getUniversity());
 
         selectUniversityExamResponseDTOS = getSelectUniversityExamResponseDTOS(universityExams, member);
@@ -88,12 +88,18 @@ public class SelectUniversityService {
                     .orElse(null);
             String status =
                     universityExamRecord == null ? BEFORE_EXAM : universityExamRecord.getExamResultStatus().getStatus();
+            String universityExamName = getUniversityExamNameForMyPage(universityExam.getUniversityExamYear(),
+                    universityExam.getUniversityExamName());
             selectUniversityExamResponseDTOS.add(
                     SelectUniversityExamResponseDTO.of(universityExam.getUniversityExamId(),
-                            universityExam.getUniversityExamName(), universityExam.getUniversityExamTimeLimit(),
+                            universityExamName, universityExam.getUniversityExamTimeLimit(),
                             status));
         }
         return selectUniversityExamResponseDTOS;
+    }
+
+    public String getUniversityExamNameForMyPage(int universityExamYear, String universityExamName) {
+        return universityExamYear + " " + universityExamName;
     }
 
     public SelectUniversityUpdateResponseDTO patchSelectUniversities(

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/entity/UniversityExam.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/entity/UniversityExam.java
@@ -8,8 +8,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
-import java.sql.Time;
-import java.time.Year;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -30,14 +28,14 @@ public class UniversityExam {
     private University university;
 
     @NotNull
-    private String examName;
+    private String universityExamName;
 
     @NotNull
-    private String examAnswerFileName;
+    private String universityExamAnswerFileName;
 
     @NotNull
-    private int examYear;
+    private int universityExamYear;
 
     @NotNull
-    private int examTimeLimit;
+    private int universityExamTimeLimit;
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/repository/UniversityExamRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/repository/UniversityExamRepository.java
@@ -9,5 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UniversityExamRepository extends JpaRepository<UniversityExam, Long> {
     Optional<UniversityExam> findByUniversityExamId(Long universityId);
 
-    List<UniversityExam> findAllByUniversity(University university);
+    List<UniversityExam> findAllByUniversityOrderByUniversityExamYearDescUniversityExamNameAsc(University university);
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/service/UniversityExamService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/service/UniversityExamService.java
@@ -34,8 +34,9 @@ public class UniversityExamService {
         UniversityExam universityExam = universityExamRepository.findByUniversityExamId(universityExamId)
                 .orElseThrow(() -> new UniversityExamException(
                         UniversityExamExceptionType.NOT_FOUND_UNIVERSITY_EXAM));
-        return UniversityExamInfoResponseDTO.of(universityExam.getUniversityExamId(), universityExam.getExamName(),
-                universityExam.getExamTimeLimit());
+        return UniversityExamInfoResponseDTO.of(universityExam.getUniversityExamId(),
+                universityExam.getUniversityExamName(),
+                universityExam.getUniversityExamTimeLimit());
     }
 
     public Page<UniversityExamImageResponseDTO> getUniversityExamImages(Long id, Pageable pageable) {
@@ -55,7 +56,7 @@ public class UniversityExamService {
                         UniversityExamExceptionType.NOT_FOUND_UNIVERSITY_EXAM));
 
         String examAnswerUrl = cloudFrontService.createPreSignedGetUrl(EXAM_ANSWER_FOLDER_NAME,
-                universityExam.getExamAnswerFileName(), universityExam.getExamTimeLimit());
+                universityExam.getUniversityExamAnswerFileName(), universityExam.getUniversityExamTimeLimit());
         List<UniversityExamImageResponseDTO> examImageUrls = new ArrayList<>();
 
         List<UniversityExamImage> UniversityExamImages = universityExamImageRepository.findAllByUniversityExam(
@@ -63,7 +64,7 @@ public class UniversityExamService {
 
         UniversityExamImages.stream().forEach(universityExamImage -> {
             String presignedGetUrl = cloudFrontService.createPreSignedGetUrl(EXAM_RESULT_FOLDER_NAME,
-                    universityExamImage.getUniversityExamImageFileName(), universityExam.getExamTimeLimit());
+                    universityExamImage.getUniversityExamImageFileName(), universityExam.getUniversityExamTimeLimit());
 
             examImageUrls.add(
                     UniversityExamImageResponseDTO.of(presignedGetUrl));

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/service/UniversityExamRecordService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/service/UniversityExamRecordService.java
@@ -43,9 +43,9 @@ public class UniversityExamRecordService {
         UniversityExamRecord universityExamRecord = getUniversityExamByUniversityExamAndMember(universityExam, member);
 
         String answerUrl = cloudFrontService.createPreSignedGetUrl(EXAM_ANSWER_FOLDER_NAME,
-                universityExam.getExamAnswerFileName(), universityExam.getExamTimeLimit());
+                universityExam.getUniversityExamAnswerFileName(), universityExam.getUniversityExamTimeLimit());
         String resultUrl = cloudFrontService.createPreSignedGetUrl(EXAM_RESULT_FOLDER_NAME,
-                universityExamRecord.getExamRecordResultFileName(), universityExam.getExamTimeLimit());
+                universityExamRecord.getExamRecordResultFileName(), universityExam.getUniversityExamTimeLimit());
 
         return UniversityExamRecordResponseDTO.of(answerUrl, resultUrl);
     }
@@ -56,7 +56,7 @@ public class UniversityExamRecordService {
         UniversityExamRecord universityExamRecord = getUniversityExamByUniversityExamAndMember(universityExam, member);
 
         String resultUrl = cloudFrontService.createPreSignedGetUrl(EXAM_RESULT_FOLDER_NAME,
-                universityExamRecord.getExamRecordResultFileName(), universityExam.getExamTimeLimit());
+                universityExamRecord.getExamRecordResultFileName(), universityExam.getUniversityExamTimeLimit());
 
         return UniversityExamRecordResultResponseDTO.of(resultUrl);
     }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#62 -> dev
- closed #62

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- UniversityExam 필드에 university 누락되어 있어 엔티티 필드 수정하고 관련 코드 업데이트 했습니다
- 대학 시험 리스트 조회에서 시험지 리스트 부분도 시험 년도 및 이름 기준으로 정렬되도록 구현했습니다


## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 최신 년도로 먼저 정렬된 후 문제 이름으로 정렬됩니다
<img width="632" alt="image" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/066f43b5-99f9-42d0-9cb6-e9132a330744">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
