### PR TITLE
[FIX] UniversityExamImage 엔티티 수정 및 대학 시험 문제 반환 시 페이지 번호 오름차순으로 반환

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/service/SelectUniversityService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/service/SelectUniversityService.java
@@ -69,7 +69,7 @@ public class SelectUniversityService {
                                                                                  Member member) {
         List<SelectUniversityExamResponseDTO> selectUniversityExamResponseDTOS;
 
-        List<UniversityExam> universityExams = universityExamRepository.findAllByUniversityOrderByUniversityExamYearDescUniversityExamNameAsc(
+        List<UniversityExam> universityExams = universityExamRepository.findAllByUniversity(
                 selectUniversity.getUniversity());
 
         selectUniversityExamResponseDTOS = getSelectUniversityExamResponseDTOS(universityExams, member);
@@ -88,18 +88,12 @@ public class SelectUniversityService {
                     .orElse(null);
             String status =
                     universityExamRecord == null ? BEFORE_EXAM : universityExamRecord.getExamResultStatus().getStatus();
-            String universityExamName = getUniversityExamNameForMyPage(universityExam.getUniversityExamYear(),
-                    universityExam.getUniversityExamName());
             selectUniversityExamResponseDTOS.add(
                     SelectUniversityExamResponseDTO.of(universityExam.getUniversityExamId(),
-                            universityExamName, universityExam.getUniversityExamTimeLimit(),
+                            universityExam.getUniversityExamName(), universityExam.getUniversityExamTimeLimit(),
                             status));
         }
         return selectUniversityExamResponseDTOS;
-    }
-
-    public String getUniversityExamNameForMyPage(int universityExamYear, String universityExamName) {
-        return universityExamYear + " " + universityExamName;
     }
 
     public SelectUniversityUpdateResponseDTO patchSelectUniversities(

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/entity/UniversityExamImage.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/entity/UniversityExamImage.java
@@ -28,4 +28,7 @@ public class UniversityExamImage {
 
     @NotNull
     private String universityExamImageFileName;
+
+    @NotNull
+    private int page;
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/entity/UniversityExamImage.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/entity/UniversityExamImage.java
@@ -28,7 +28,6 @@ public class UniversityExamImage {
 
     @NotNull
     private String universityExamImageFileName;
-
-    @NotNull
+    
     private int page;
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/repository/UniversityExamImageRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/repository/UniversityExamImageRepository.java
@@ -9,8 +9,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UniversityExamImageRepository extends JpaRepository<UniversityExamImage, Long> {
-    Page<UniversityExamImage> findAllByUniversityExam(UniversityExam universityExam, Pageable pageable);
+    Page<UniversityExamImage> findAllByUniversityExamOrderByPageAsc(UniversityExam universityExam,
+                                                                    Pageable pageable);
 
-    List<UniversityExamImage> findAllByUniversityExam(UniversityExam universityExam);
+    List<UniversityExamImage> findAllByUniversityExamOrderByPageAsc(UniversityExam universityExam);
 
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/repository/UniversityExamRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/repository/UniversityExamRepository.java
@@ -9,5 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UniversityExamRepository extends JpaRepository<UniversityExam, Long> {
     Optional<UniversityExam> findByUniversityExamId(Long universityId);
 
-    List<UniversityExam> findAllByUniversityOrderByUniversityExamYearDescUniversityExamNameAsc(University university);
+    List<UniversityExam> findAllByUniversity(University university);
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/aws/FolderName.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/aws/FolderName.java
@@ -4,4 +4,5 @@ public abstract class FolderName {
     public static final String EXAM_ANSWER_FOLDER_NAME = "exam-answer/";
     public static final String EXAM_RESULT_FOLDER_NAME = "exam-result/";
     public static final String EXAM_SHEET_FOLDER_NAME = "exam-sheet/";
+    public static final String EXAM_IMAGE_FOLDER_NAME = "exam-image/";
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/#64 -> dev 
- closed #64


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- UniversityExamImage 엔티티 필드 수정했습니다
- page 필드 추가에 따라 page를 기준으로 오름차순 정렬을 하여 이미지 리스트를 반환하도록 관련 로직을 수정했습니다


## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 포스트맨에서는 페이지 번호를 반환하지 않아 콘솔에 찍어서 보여드립니다 !
<img width="334" alt="스크린샷 2024-01-12 오후 8 35 46" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/f86827e9-78d6-4f14-9ddf-bf8faa834362">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
