### PR TITLE
[FIX] swagger 적용 이후 나타나는 500 에러 해결

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/AuthApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/AuthApi.java
@@ -11,7 +11,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 
 @Tag(name = "auth", description = "인증 관련 API")
@@ -26,8 +29,8 @@ public interface AuthApi {
 
     @Operation(summary = "소셜 로그인", description = "네이버 소셜 로그인을 합니다.")
     ResponseEntity<com.nonsoolmate.nonsoolmateServer.global.response.ApiResponse<MemberAuthResponseDTO>> login(
-            @Parameter(description = "인가 코드", required = true) final String authorizationCode,
-            @Parameter(description = "플랫폼 타입(ex.'NAVER')", required = true) final MemberRequestDTO request,
+            @Parameter(description = "인가 코드", required = true) @RequestHeader(value = "authorization-code") final String authorizationCode,
+            @Parameter(description = "플랫폼 타입(ex.'NAVER')", required = true) @RequestBody @Valid final MemberRequestDTO request,
             HttpServletResponse response);
 
     @Operation(summary = "액세스 토큰 & 리프레시 토큰 재발급", description = "액세스 토큰 및 리프레시 토큰을 재발급 받습니다.")

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/AuthController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/AuthController.java
@@ -39,6 +39,7 @@ public class AuthController implements AuthApi{
     @Value("${spring.security.oauth2.client.naver.redirect-uri}")
     private String redirectUri;
 
+    @Override
     @PostMapping("/social/login")
     public ResponseEntity<ApiResponse<MemberAuthResponseDTO>> login(
             @RequestHeader(value = "authorization-code") final String authorizationCode,
@@ -54,6 +55,7 @@ public class AuthController implements AuthApi{
         return ResponseEntity.ok().body(ApiResponse.success(AuthSuccessType.LOGIN_SUCCESS, responseDTO));
     }
 
+    @Override
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse<MemberReissueResponseDTO>> reissue(HttpServletRequest request,
                                                                          HttpServletResponse response) {

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/AuthController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/AuthController.java
@@ -42,7 +42,7 @@ public class AuthController implements AuthApi{
     @Override
     @PostMapping("/social/login")
     public ResponseEntity<ApiResponse<MemberAuthResponseDTO>> login(
-            @RequestHeader(value = "authorization-code") final String authorizationCode,
+            final String authorizationCode,
             @RequestBody @Valid final
             MemberRequestDTO request, HttpServletResponse response) {
         MemberSignUpVO vo = authServiceProvider.getAuthService(request.platformType())

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/MemberApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/MemberApi.java
@@ -4,6 +4,7 @@ import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.N
 import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.TicketResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
 import com.nonsoolmate.nonsoolmateServer.global.response.ApiResponse;
+import com.nonsoolmate.nonsoolmateServer.global.security.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -21,9 +22,9 @@ public interface MemberApi {
 
     @Operation(summary = "마이페이지: 이름", description = "내 이름을 조회합니다.")
     ResponseEntity<ApiResponse<NameResponseDTO>> getName(
-            Member member);
+            @AuthUser Member member);
 
     @Operation(summary = "내 정보 확인: 첨삭권 개수", description = "내 첨삭권 갯수를 조회합니다.")
-    ResponseEntity<ApiResponse<TicketResponseDTO>> getTicket(Member member);
+    ResponseEntity<ApiResponse<TicketResponseDTO>> getTicket(@AuthUser Member member);
 
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/MyController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/MyController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MyController implements MemberApi{
     private final MemberService memberService;
 
+    @Override
     @GetMapping("/name")
     public ResponseEntity<ApiResponse<NameResponseDTO>> getName(@AuthUser Member member) {
         return ResponseEntity.ok()
@@ -28,6 +29,7 @@ public class MyController implements MemberApi{
                         memberService.getNickname(member)));
     }
 
+    @Override
     @GetMapping("/ticket")
     public ResponseEntity<ApiResponse<TicketResponseDTO>> getTicket(@AuthUser Member member) {
         return ResponseEntity.ok()

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/SelectUniversityApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/SelectUniversityApi.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "SelectUniversity", description = "목표 대학과 관련된 API")
 public interface SelectUniversityApi {
 
+
     @ApiResponses(
             value = {
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200"),

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/SelectUniversityApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/SelectUniversityApi.java
@@ -13,7 +13,10 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 
 
 @Tag(name = "SelectUniversity", description = "목표 대학과 관련된 API")
@@ -37,5 +40,5 @@ public interface SelectUniversityApi {
     @Operation(summary = "목표대학 설정: 리스트 선택", description = "내 목표 대학들 리스트를 업데이트(수정) 합니다.")
     ResponseEntity<ApiResponse<SelectUniversityUpdateResponseDTO>> patchSelectUniversities(
             @AuthUser Member member,
-            @Parameter(description = "선택 대학교 Id", required = true) List<SelectUniversityRequestDTO> request);
+            @Parameter(description = "선택 대학교 Id", required = true) @RequestBody @Valid List<SelectUniversityRequestDTO> request);
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/SelectUniversityController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/SelectUniversityController.java
@@ -31,6 +31,7 @@ public class SelectUniversityController implements SelectUniversityApi {
 
     private final SelectUniversityService selectUniversityService;
 
+    @Override
     @GetMapping
     public ResponseEntity<ApiResponse<List<SelectUniversityResponseDTO>>> getSelectUniversities(
             @AuthUser Member member) {
@@ -39,6 +40,7 @@ public class SelectUniversityController implements SelectUniversityApi {
                 selectUniversityService.getSelectUniversities(member)));
     }
 
+    @Override
     @GetMapping("/exam")
     public ResponseEntity<ApiResponse<List<SelectUniversityExamsResponseDTO>>> getSelectUniversityExams(
             @AuthUser Member member) {
@@ -46,6 +48,7 @@ public class SelectUniversityController implements SelectUniversityApi {
                 selectUniversityService.getSelectUniversityExams(member)));
     }
 
+    @Override
     @PatchMapping
     public ResponseEntity<ApiResponse<SelectUniversityUpdateResponseDTO>> patchSelectUniversities(
             @AuthUser Member member,

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityApi.java
@@ -1,5 +1,6 @@
 package com.nonsoolmate.nonsoolmateServer.domain.university.controller;
 
+import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageAndAnswerResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamInfoResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.global.response.ApiResponse;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 
@@ -26,11 +28,15 @@ public interface UniversityApi {
 
     @Operation(summary = "시험 보기: 시험 이름 & 제한 시간", description = "시험 응시 화면의 이름 및 제한 시간을 조회합니다.")
     ResponseEntity<ApiResponse<UniversityExamInfoResponseDTO>> getUniversityExam(
-            @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) Long universityExamId);
+            @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long universityExamId);
 
     @Operation(summary = "시험 보기: 문제지 [페이지네이션]", description = "시험 응시 화면의 문제지를 조회합니다.")
     ResponseEntity<ApiResponse<Page<UniversityExamImageResponseDTO>>> getUniversityExamImages(
-            @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) Long id,
+            @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long id,
             @RequestParam(defaultValue = "0") int page,
             Pageable pageable);
+
+    @Operation(summary= "해제: 문제이미지_해제PDF", description = "시험 문제 이미지 및 해제 PDF를 조회합니다.")
+    ResponseEntity<ApiResponse<UniversityExamImageAndAnswerResponseDTO>> getUniversityExamImageAndAnswer(
+            @PathVariable("id") Long universityExamId);
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UniversityExamController implements UniversityApi{
     private final UniversityExamService universityExamService;
 
+    @Override
     @GetMapping("/{id}/info")
     public ResponseEntity<ApiResponse<UniversityExamInfoResponseDTO>> getUniversityExam(
             @PathVariable("id") Long universityExamId) {
@@ -34,6 +35,7 @@ public class UniversityExamController implements UniversityApi{
                 universityExamService.getUniversityExam(universityExamId)));
     }
 
+    @Override
     @GetMapping("{id}/image")
     public ResponseEntity<ApiResponse<Page<UniversityExamImageResponseDTO>>> getUniversityExamImages(
             @PathVariable("id") Long id, @RequestParam(defaultValue = "0") int page, Pageable pageable) {
@@ -43,6 +45,7 @@ public class UniversityExamController implements UniversityApi{
                 .body(ApiResponse.success(UniversityExamSuccessType.GET_UNIVERSITY_EXAM_IMAGE_SUCCESS, images));
     }
 
+    @Override
     @GetMapping("{id}/answer")
     public ResponseEntity<ApiResponse<UniversityExamImageAndAnswerResponseDTO>> getUniversityExamImageAndAnswer(
             @PathVariable("id") Long universityExamId

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/UniversityExamRecordApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/UniversityExamRecordApi.java
@@ -13,7 +13,10 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 
 @Tag(name = "UniversityExamRecord", description = "시험 응시 기록과 관련된 API")
@@ -28,12 +31,12 @@ public interface UniversityExamRecordApi {
 
     @Operation(summary = "첨삭: 첨삭 PDF_해제PDF", description = "첨삭 pdf 및 해제 pdf를 조회합니다.")
     ResponseEntity<ApiResponse<UniversityExamRecordResponseDTO>> getUniversityExamRecord(
-            @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) Long universityExamId,
+            @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long universityExamId,
             @AuthUser Member member);
 
     @Operation(summary = "첨삭: 첨삭 PDF 저장", description = "첨삭 pdf를 조회합니다.")
     ResponseEntity<ApiResponse<UniversityExamRecordResultResponseDTO>> getUniversityExamRecordResult(
-            @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) Long universityExamId,
+            @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long universityExamId,
             @AuthUser Member member);
 
     @Operation(summary = "시험 보기: [1] 답안지 업로드 PresignedUrl 조회 API", description = "답안지(시험응시기록) 업로드를 위한 PresignedUrl를 조회합니다.")
@@ -41,6 +44,6 @@ public interface UniversityExamRecordApi {
 
     @Operation(summary = "시험보기: [3] 답안지 업로드 후 시험 기록 API", description = "답안지(시험응시기록) 업로드 후 서버에 기록하기 위해 호출합니다.")
     ResponseEntity<ApiResponse<UniversityExamRecordIdResponse>> createUniversityExamRecord(
-            @Parameter(description = "해당 대학교 시험 Id (examId), 시험 응시 소요 시간, 답안지(응시 기록) 파일 이름", required = true) CreateUniversityExamRequestDTO createUniversityExamRequestDTO,
+            @Parameter(description = "해당 대학교 시험 Id (examId), 시험 응시 소요 시간, 답안지(응시 기록) 파일 이름", required = true) @Valid @RequestBody CreateUniversityExamRequestDTO createUniversityExamRequestDTO,
             @AuthUser Member member);
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/UniversityExamRecordController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/UniversityExamRecordController.java
@@ -36,7 +36,7 @@ public class UniversityExamRecordController implements UniversityExamRecordApi {
     private final UniversityExamRecordService universityExamRecordService;
     private final UniversityExamRecordSheetService universityExamRecordSheetService;
 
-
+    @Override
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<UniversityExamRecordResponseDTO>> getUniversityExamRecord(
             @PathVariable("id") Long universityExamId, @AuthUser Member member) {
@@ -44,6 +44,7 @@ public class UniversityExamRecordController implements UniversityExamRecordApi {
                 universityExamRecordService.getUniversityExamRecord(universityExamId, member)));
     }
 
+    @Override
     @GetMapping("/result/{id}")
     public ResponseEntity<ApiResponse<UniversityExamRecordResultResponseDTO>> getUniversityExamRecordResult(
             @PathVariable("id") Long universityExamId, @AuthUser Member member) {
@@ -51,6 +52,7 @@ public class UniversityExamRecordController implements UniversityExamRecordApi {
                 universityExamRecordService.getUniversityExamRecordResult(universityExamId, member)));
     }
 
+    @Override
     @GetMapping("/sheet/presigned")
     public ResponseEntity<ApiResponse<UniversityExamSheetPreSignedUrlResponseDTO>> getUniversityExamSheetPreSignedUrl() {
         PreSignedUrlVO universityExamRecordSheetPreSignedUrlVO = universityExamRecordSheetService.getUniversityExamRecordSheetPreSignedUrl();
@@ -60,6 +62,7 @@ public class UniversityExamRecordController implements UniversityExamRecordApi {
                         universityExamRecordSheetPreSignedUrlVO.getUrl())));
     }
 
+    @Override
     @PostMapping("/sheet")
     public ResponseEntity<ApiResponse<UniversityExamRecordIdResponse>> createUniversityExamRecord(
             @Valid @RequestBody CreateUniversityExamRequestDTO createUniversityExamRequestDTO,


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/#91 -> dev
- closed #91 


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 메서드 오버라이드를 하지 않고, 인터페이스에서 @RequestBody와 같은 어노테이션이 붙지 않아 다음과 같은 에러가 발생해 해결했습니다
`HV000151: A method overriding another method must not redefine the parameter constraint configuration, but method SelectUniversityController#patchSelectUniversities(Member, List) redefines the configuration of SelectUniversityApi#patchSelectUniversities(Member, List).`


## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
