### PR TITLE
[FIX] 첨삭, 해제 PDF 조회 API에서 PreSignedUrl 유효시간을 2분으로 수정

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/service/UniversityExamRecordService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/service/UniversityExamRecordService.java
@@ -45,7 +45,7 @@ public class UniversityExamRecordService {
         String answerUrl = cloudFrontService.createPreSignedGetUrl(EXAM_ANSWER_FOLDER_NAME,
                 universityExam.getUniversityExamAnswerFileName(), universityExam.getUniversityExamTimeLimit());
         String resultUrl = cloudFrontService.createPreSignedGetUrl(EXAM_RESULT_FOLDER_NAME,
-                universityExamRecord.getExamRecordResultFileName(), universityExam.getUniversityExamTimeLimit());
+                universityExamRecord.getExamRecordResultFileName(), 2);
 
         return UniversityExamRecordResponseDTO.of(universityExam.getUniversityExamFullName(), answerUrl, resultUrl);
     }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/#94 -> dev
- closed #94


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 클라이언트 PDF 뷰어 테스트를 위해  첨삭, 해제 PDF 조회 API에서 PreSignedUrl 유효시간을 2분으로 수정했습니다


## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="769" alt="image" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/65bdd8f1-27c3-40d9-9646-1662e946419d">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
