### PR TITLE
[FEAT] 이미 응시한 대학 시험에 대해 다시 시험 기록 API를 호출하는 경우에 대한 에러 추가

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/UniversityExamRecordApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/UniversityExamRecordApi.java
@@ -25,6 +25,7 @@ public interface UniversityExamRecordApi {
     @ApiResponses(
             value = {
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", content = @Content),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", content = @Content)
             }
     )

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/exception/UniversityExamRecordExceptionType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/exception/UniversityExamRecordExceptionType.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum UniversityExamRecordExceptionType implements BusinessExceptionType {
     NOT_FOUND_UNIVERSITY_EXAM_RECORD(HttpStatus.NOT_FOUND, "존재하지 않는 시험 응시 기록입니다."),
-    CREATE_UNIVERSITY_EXAM_RECORD_FAIL(HttpStatus.BAD_REQUEST, "대학 시험 기록 생성에 실패했습니다.");
+    CREATE_UNIVERSITY_EXAM_RECORD_FAIL(HttpStatus.BAD_REQUEST, "대학 시험 기록 생성에 실패했습니다."),
+    ALREADY_CREATE_EXAM_RECORD(HttpStatus.BAD_REQUEST, "이미 응시한 대학 시험입니다");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#97 -> dev
- closed #97


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 이미 응시한 대학 시험에 대해 다시 시험 기록 API를 호출하는 경우에 대한 에러를 추가했습니다


## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="759" alt="image" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/feee6097-97e2-4f13-a0d8-644e65101e3b">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
