### PR TITLE
[FEAT] Swagger 설정에서 각 컨트롤러 별 에러 처리, DTO 설명 추가

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/AuthApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/AuthApi.java
@@ -32,7 +32,7 @@ public interface AuthApi {
     @Operation(summary = "소셜 로그인", description = "네이버 소셜 로그인을 합니다.")
     ResponseEntity<SuccessResponse<MemberAuthResponseDTO>> login(
             @Parameter(description = "네이버로부터 발급받은 인가 코드", required = true) @RequestHeader(value = "authorization-code") final String authorizationCode,
-            @Parameter(description = "소셜 플랫폼 타입 (ex.'NAVER')", required = true) @RequestBody @Valid final MemberRequestDTO request);
+            @RequestBody @Valid final MemberRequestDTO request);
 
     @ApiResponses(
             value = {

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/AuthApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/AuthApi.java
@@ -3,10 +3,12 @@ package com.nonsoolmate.nonsoolmateServer.domain.auth.controller;
 import com.nonsoolmate.nonsoolmateServer.domain.auth.controller.dto.request.MemberRequestDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.auth.controller.dto.response.MemberAuthResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.auth.controller.dto.response.MemberReissueResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.global.response.ErrorResponse;
 import com.nonsoolmate.nonsoolmateServer.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,16 +24,23 @@ public interface AuthApi {
 
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "200"),
-                    @ApiResponse(responseCode = "404", content = @Content)
+                    @ApiResponse(responseCode = "200", description = "로그인에 성공하였습니다"),
+                    @ApiResponse(responseCode = "201", description = "회원가입에 성공하였습니다"),
+                    @ApiResponse(responseCode = "400", description = "유효하지 않은 플랫폼 인가코드입니다, 입력값이 올바르지 않습니다, 올바르지 않은 플랫폼 유형입니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
-
     @Operation(summary = "소셜 로그인", description = "네이버 소셜 로그인을 합니다.")
     ResponseEntity<SuccessResponse<MemberAuthResponseDTO>> login(
-            @Parameter(description = "인가 코드", required = true) @RequestHeader(value = "authorization-code") final String authorizationCode,
-            @Parameter(description = "플랫폼 타입(ex.'NAVER')", required = true) @RequestBody @Valid final MemberRequestDTO request);
+            @Parameter(description = "네이버로부터 발급받은 인가 코드", required = true) @RequestHeader(value = "authorization-code") final String authorizationCode,
+            @Parameter(description = "소셜 플랫폼 타입 (ex.'NAVER')", required = true) @RequestBody @Valid final MemberRequestDTO request);
 
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "리프레시 토큰 재발급에 성공하였습니다."),
+                    @ApiResponse(responseCode = "400", description = "서비스에서 발급되지 않은 리프레시 토큰입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "기한이 만료된 리프레시 토큰입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
     @Operation(summary = "액세스 토큰 & 리프레시 토큰 재발급", description = "액세스 토큰 및 리프레시 토큰을 재발급 받습니다.")
     ResponseEntity<SuccessResponse<MemberReissueResponseDTO>> reissue(
             HttpServletRequest request);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/dto/request/MemberRequestDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/dto/request/MemberRequestDTO.java
@@ -1,11 +1,12 @@
 package com.nonsoolmate.nonsoolmateServer.domain.auth.controller.dto.request;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-
+@Schema(name = "MemberRequestDTO", description = "소셜 로그인 요청 DTO")
 public record MemberRequestDTO(
         @NotNull
+        @Schema(description = "소셜 플랫폼 타입", example = "NAVER")
         String platformType) {
-
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/dto/response/MemberAuthResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/dto/response/MemberAuthResponseDTO.java
@@ -1,10 +1,15 @@
 package com.nonsoolmate.nonsoolmateServer.domain.auth.controller.dto.response;
 
 import com.nonsoolmate.nonsoolmateServer.external.oauth.service.vo.enums.AuthType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-public record MemberAuthResponseDTO(@NotNull Long memberId, @NotNull AuthType authType, @NotNull String memberName,
-                                    @NotNull String accessToken, @NotNull String refreshToken) {
+@Schema(name = "MemberAuthResponseDTO", description = "소셜 로그인 응답 DTO")
+public record MemberAuthResponseDTO(@NotNull @Schema(description = "사용자 id", example = "1") Long memberId,
+                                    @NotNull @Schema(description = "회원가입/로그인 여부", example = "LOGIN 또는 SIGN_UP") AuthType authType,
+                                    @NotNull @Schema(description = "사용자 이름", example = "류가은") String memberName,
+                                    @NotNull @Schema(description = "액세스 토큰") String accessToken,
+                                    @NotNull @Schema(description = "리프레시 토큰") String refreshToken) {
     public static MemberAuthResponseDTO of(Long memberId, AuthType authType, String memberName, String accessToken,
                                            String refreshToken) {
         return new MemberAuthResponseDTO(memberId, authType, memberName, accessToken, refreshToken);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/dto/response/MemberReissueResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/dto/response/MemberReissueResponseDTO.java
@@ -1,11 +1,15 @@
 package com.nonsoolmate.nonsoolmateServer.domain.auth.controller.dto.response;
 
 import com.nonsoolmate.nonsoolmateServer.external.oauth.service.vo.enums.AuthType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-public record MemberReissueResponseDTO(@NotNull Long memberId, @NotNull String accessToken, @NotNull String refreshToken) {
+@Schema(name = "MemberReissueResponseDTO", description = "리프레시 토큰 재발급 응답 DTO")
+public record MemberReissueResponseDTO(@NotNull @Schema(description = "사용자 id", example = "1") Long memberId,
+                                       @NotNull @Schema(description = "액세스 토큰") String accessToken,
+                                       @NotNull @Schema(description = "리프레시 토큰") String refreshToken) {
     public static MemberReissueResponseDTO of(Long memberId, String accessToken,
-                                           String refreshToken) {
+                                              String refreshToken) {
         return new MemberReissueResponseDTO(memberId, accessToken, refreshToken);
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/dto/response/MemberReissueResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/dto/response/MemberReissueResponseDTO.java
@@ -1,6 +1,5 @@
 package com.nonsoolmate.nonsoolmateServer.domain.auth.controller.dto.response;
 
-import com.nonsoolmate.nonsoolmateServer.external.oauth.service.vo.enums.AuthType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/MemberApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/MemberApi.java
@@ -3,10 +3,13 @@ package com.nonsoolmate.nonsoolmateServer.domain.member.controller;
 import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.NameResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.TicketResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
+import com.nonsoolmate.nonsoolmateServer.global.response.ErrorResponse;
 import com.nonsoolmate.nonsoolmateServer.global.response.SuccessResponse;
 import com.nonsoolmate.nonsoolmateServer.global.security.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -15,15 +18,18 @@ import org.springframework.http.ResponseEntity;
 public interface MemberApi {
     @ApiResponses(
             value = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", content = @Content)
+                    @ApiResponse(responseCode = "200", description = "이름 조회에 성공하였습니다.")
             }
     )
-
     @Operation(summary = "마이페이지: 이름", description = "내 이름을 조회합니다.")
     ResponseEntity<SuccessResponse<NameResponseDTO>> getName(
             @AuthUser Member member);
 
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "이름 조회에 성공하였습니다.")
+            }
+    )
     @Operation(summary = "내 정보 확인: 첨삭권 개수", description = "내 첨삭권 갯수를 조회합니다.")
     ResponseEntity<SuccessResponse<TicketResponseDTO>> getTicket(@AuthUser Member member);
 

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/dto/response/NameResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/dto/response/NameResponseDTO.java
@@ -1,6 +1,9 @@
 package com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response;
 
-public record NameResponseDTO(String memberName) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "NameResponseDTO", description = "멤버 이름 응답 DTO")
+public record NameResponseDTO(@Schema(description = "멤버 이름", example = "류가은") String memberName) {
     static public NameResponseDTO of(String memberName) {
         return new NameResponseDTO(memberName);
     }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/dto/response/NameResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/dto/response/NameResponseDTO.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "NameResponseDTO", description = "멤버 이름 응답 DTO")
 public record NameResponseDTO(@Schema(description = "멤버 이름", example = "류가은") String memberName) {
-    static public NameResponseDTO of(String memberName) {
+    public static NameResponseDTO of(String memberName) {
         return new NameResponseDTO(memberName);
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/dto/response/TicketResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/dto/response/TicketResponseDTO.java
@@ -1,6 +1,10 @@
 package com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response;
 
-public record TicketResponseDTO(String memberName, int ticketCount) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "TicketResponseDTO", description = "멤버 첨삭권 응답 DTO")
+public record TicketResponseDTO(@Schema(description = "멤버 이름", example = "류가은") String memberName,
+                                @Schema(description = "사용자 첨삭권 개수", example = "5") int ticketCount) {
     static public TicketResponseDTO of(String memberName, int ticketCount) {
         return new TicketResponseDTO(memberName, ticketCount);
     }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/dto/response/TicketResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/dto/response/TicketResponseDTO.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(name = "TicketResponseDTO", description = "멤버 첨삭권 응답 DTO")
 public record TicketResponseDTO(@Schema(description = "멤버 이름", example = "류가은") String memberName,
                                 @Schema(description = "사용자 첨삭권 개수", example = "5") int ticketCount) {
-    static public TicketResponseDTO of(String memberName, int ticketCount) {
+    public static TicketResponseDTO of(String memberName, int ticketCount) {
         return new TicketResponseDTO(memberName, ticketCount);
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/SelectUniversityApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/SelectUniversityApi.java
@@ -5,11 +5,14 @@ import com.nonsoolmate.nonsoolmateServer.domain.selectUniversity.controller.dto.
 import com.nonsoolmate.nonsoolmateServer.domain.selectUniversity.controller.dto.response.SelectUniversityExamsResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.selectUniversity.controller.dto.response.SelectUniversityResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.selectUniversity.controller.dto.response.SelectUniversityUpdateResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.global.response.ErrorResponse;
 import com.nonsoolmate.nonsoolmateServer.global.response.SuccessResponse;
 import com.nonsoolmate.nonsoolmateServer.global.security.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -22,24 +25,32 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "SelectUniversity", description = "목표 대학과 관련된 API")
 public interface SelectUniversityApi {
 
-
     @ApiResponses(
             value = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", content = @Content)
+                    @ApiResponse(responseCode = "200", description = "목표 대학 조회에 성공하였습니다."),
             }
     )
-
     @Operation(summary = "목표대학 설정: 리스트 조회", description = "내 목표 대학 리스트를 조회합니다.")
     ResponseEntity<SuccessResponse<List<SelectUniversityResponseDTO>>> getSelectUniversities(
             @AuthUser Member member);
 
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "목표 대학 시험 리스트 조회에 성공하였습니다."),
+            }
+    )
     @Operation(summary = "마이 페이지: 대학별 시험 리스트 조회", description = "내 목표 대학들의 시험 리스트를 조회합니다.")
     ResponseEntity<SuccessResponse<List<SelectUniversityExamsResponseDTO>>> getSelectUniversityExams(
             @AuthUser Member member);
 
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "목표 대학 시험 리스트 조회에 성공하였습니다."),
+                    @ApiResponse(responseCode = "400", description = "유효한 목표 대학교가 아닙니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
     @Operation(summary = "목표대학 설정: 리스트 선택", description = "내 목표 대학들 리스트를 업데이트(수정) 합니다.")
     ResponseEntity<SuccessResponse<SelectUniversityUpdateResponseDTO>> patchSelectUniversities(
             @AuthUser Member member,
-            @Parameter(description = "선택 대학교 Id", required = true) @RequestBody @Valid List<SelectUniversityRequestDTO> request);
+            @RequestBody @Valid List<SelectUniversityRequestDTO> request);
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/request/SelectUniversityRequestDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/request/SelectUniversityRequestDTO.java
@@ -1,8 +1,9 @@
 package com.nonsoolmate.nonsoolmateServer.domain.selectUniversity.controller.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public record SelectUniversityRequestDTO(
-        @NotNull Long universityId
+        @NotNull @Schema(name="사용자가 선택한 대학 id", example="1") Long universityId
 ) {
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/request/SelectUniversityRequestDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/request/SelectUniversityRequestDTO.java
@@ -4,6 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public record SelectUniversityRequestDTO(
-        @NotNull @Schema(name="사용자가 선택한 대학 id", example="1") Long universityId
+        @NotNull @Schema(description="사용자가 선택한 대학 id", example="1") Long universityId
 ) {
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityExamResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityExamResponseDTO.java
@@ -1,7 +1,12 @@
 package com.nonsoolmate.nonsoolmateServer.domain.selectUniversity.controller.dto.response;
 
-public record SelectUniversityExamResponseDTO(Long examId, String examName, int examTimeLimit,
-                                              String examStatus) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "SelectUniversityExamResponseDTO", description = "대학별 시험 조회 요청 DTO")
+public record SelectUniversityExamResponseDTO(@Schema(name = "시험 id", example = "1") Long examId,
+                                              @Schema(name = "시험 이름", example = "경영경제1") String examName,
+                                              @Schema(name = "시험 제한 시간(초)", example = "3600") int examTimeLimit,
+                                              @Schema(name = "시험 응시 상태", example = "시험 응시 전") String examStatus) {
     public static SelectUniversityExamResponseDTO of(Long examId, String examName, int examTimeLimit,
                                                      String examStatus) {
         return new SelectUniversityExamResponseDTO(examId, examName, examTimeLimit, examStatus);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityExamResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityExamResponseDTO.java
@@ -3,10 +3,10 @@ package com.nonsoolmate.nonsoolmateServer.domain.selectUniversity.controller.dto
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "SelectUniversityExamResponseDTO", description = "대학별 시험 조회 요청 DTO")
-public record SelectUniversityExamResponseDTO(@Schema(name = "시험 id", example = "1") Long examId,
-                                              @Schema(name = "시험 이름", example = "경영경제1") String examName,
-                                              @Schema(name = "시험 제한 시간(초)", example = "3600") int examTimeLimit,
-                                              @Schema(name = "시험 응시 상태", example = "시험 응시 전") String examStatus) {
+public record SelectUniversityExamResponseDTO(@Schema(description = "시험 id", example = "1") Long examId,
+                                              @Schema(description = "시험 이름", example = "경영경제1") String examName,
+                                              @Schema(description = "시험 제한 시간(초)", example = "3600") int examTimeLimit,
+                                              @Schema(description = "시험 응시 상태", example = "시험 응시 전") String examStatus) {
     public static SelectUniversityExamResponseDTO of(Long examId, String examName, int examTimeLimit,
                                                      String examStatus) {
         return new SelectUniversityExamResponseDTO(examId, examName, examTimeLimit, examStatus);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityExamsResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityExamsResponseDTO.java
@@ -1,9 +1,13 @@
 package com.nonsoolmate.nonsoolmateServer.domain.selectUniversity.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record SelectUniversityExamsResponseDTO(Long universityId, String universityName, String universityCollege,
-                                               List<SelectUniversityExamResponseDTO> examList) {
+@Schema(name = "SelectUniversityExamsResponseDTO", description = "대학별 시험 리스트 조회 요청 DTO")
+public record SelectUniversityExamsResponseDTO(@Schema(name = "대학 id", example = "대학 이름") Long universityId,
+                                               @Schema(name = "대학 이름", example = "중앙대학교") String universityName,
+                                               @Schema(name = "단과대학 이름", example = "경영경제") String universityCollege,
+                                               @Schema(name = "시험 리스트") List<SelectUniversityExamResponseDTO> examList) {
     public static SelectUniversityExamsResponseDTO of(Long universityId, String universityName,
                                                       String universityCollege,
                                                       List<SelectUniversityExamResponseDTO> examList) {

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityExamsResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityExamsResponseDTO.java
@@ -4,10 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 @Schema(name = "SelectUniversityExamsResponseDTO", description = "대학별 시험 리스트 조회 요청 DTO")
-public record SelectUniversityExamsResponseDTO(@Schema(name = "대학 id", example = "대학 이름") Long universityId,
-                                               @Schema(name = "대학 이름", example = "중앙대학교") String universityName,
-                                               @Schema(name = "단과대학 이름", example = "경영경제") String universityCollege,
-                                               @Schema(name = "시험 리스트") List<SelectUniversityExamResponseDTO> examList) {
+public record SelectUniversityExamsResponseDTO(@Schema(description = "대학 id", example = "대학 이름") Long universityId,
+                                               @Schema(description = "대학 이름", example = "중앙대학교") String universityName,
+                                               @Schema(description = "단과대학 이름", example = "경영경제") String universityCollege,
+                                               @Schema(description = "시험 리스트") List<SelectUniversityExamResponseDTO> examList) {
     public static SelectUniversityExamsResponseDTO of(Long universityId, String universityName,
                                                       String universityCollege,
                                                       List<SelectUniversityExamResponseDTO> examList) {

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityResponseDTO.java
@@ -1,10 +1,15 @@
 package com.nonsoolmate.nonsoolmateServer.domain.selectUniversity.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(name = "SelectUniversityResponseDTO", description = "선택 대학 조회 응답 DTO")
 public record SelectUniversityResponseDTO(
-    Long universityId, String universityName, String collegeName, boolean memberStatus
+        @Schema(name = "대학 id", example = "1") Long universityId,
+        @Schema(name = "대학 이름", example = "중앙대학교") String universityName,
+        @Schema(name = "단과대학 이름", example = "경영경제") String collegeName,
+        @Schema(name = "대학 선택 여부", example = "true") boolean memberStatus
 ) {
-    static public SelectUniversityResponseDTO of(Long universityId, String universityName, String collegeName, boolean memberStatus) {
+    public static SelectUniversityResponseDTO of(Long universityId, String universityName, String collegeName, boolean memberStatus) {
         return new SelectUniversityResponseDTO(universityId, universityName, collegeName, memberStatus);
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityResponseDTO.java
@@ -4,10 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "SelectUniversityResponseDTO", description = "선택 대학 조회 응답 DTO")
 public record SelectUniversityResponseDTO(
-        @Schema(name = "대학 id", example = "1") Long universityId,
-        @Schema(name = "대학 이름", example = "중앙대학교") String universityName,
-        @Schema(name = "단과대학 이름", example = "경영경제") String collegeName,
-        @Schema(name = "대학 선택 여부", example = "true") boolean memberStatus
+        @Schema(description = "대학 id", example = "1") Long universityId,
+        @Schema(description = "대학 이름", example = "중앙대학교") String universityName,
+        @Schema(description = "단과대학 이름", example = "경영경제") String collegeName,
+        @Schema(description = "대학 선택 여부", example = "true") boolean memberStatus
 ) {
     public static SelectUniversityResponseDTO of(Long universityId, String universityName, String collegeName, boolean memberStatus) {
         return new SelectUniversityResponseDTO(universityId, universityName, collegeName, memberStatus);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityUpdateResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityUpdateResponseDTO.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "SelectUniversityUpdateResponseDTO", description = "목표 대학 리스트 선택 응답 DTO")
 public record SelectUniversityUpdateResponseDTO(
-        @Schema(name="선택 완료 여부", example="true") boolean isSelected
+        @Schema(description="선택 완료 여부", example="true") boolean isSelected
 ) {
     public static SelectUniversityUpdateResponseDTO of(boolean isSelected) {
         return new SelectUniversityUpdateResponseDTO(isSelected);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityUpdateResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/dto/response/SelectUniversityUpdateResponseDTO.java
@@ -1,9 +1,12 @@
 package com.nonsoolmate.nonsoolmateServer.domain.selectUniversity.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "SelectUniversityUpdateResponseDTO", description = "목표 대학 리스트 선택 응답 DTO")
 public record SelectUniversityUpdateResponseDTO(
-        boolean isSelected
+        @Schema(name="선택 완료 여부", example="true") boolean isSelected
 ) {
-    static public SelectUniversityUpdateResponseDTO of(boolean isSelected) {
+    public static SelectUniversityUpdateResponseDTO of(boolean isSelected) {
         return new SelectUniversityUpdateResponseDTO(isSelected);
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityApi.java
@@ -3,10 +3,13 @@ package com.nonsoolmate.nonsoolmateServer.domain.university.controller;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageAndAnswerResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamInfoResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.global.response.ErrorResponse;
 import com.nonsoolmate.nonsoolmateServer.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
@@ -18,24 +21,34 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "UniversityExam", description = "대학 시험 정보와 관련된 API")
 public interface UniversityApi {
-
     @ApiResponses(
             value = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", content = @Content)
+                    @ApiResponse(responseCode = "200", description = "대학 시험 정보 조회에 성공했습니다"),
+                    @ApiResponse(responseCode = "400", description = "존재하지 않는 대학 시험입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
-
     @Operation(summary = "시험 보기: 시험 이름 & 제한 시간", description = "시험 응시 화면의 이름 및 제한 시간을 조회합니다.")
     ResponseEntity<SuccessResponse<UniversityExamInfoResponseDTO>> getUniversityExam(
             @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long universityExamId);
 
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "대학 시험 이미지 조회에 성공했습니다"),
+                    @ApiResponse(responseCode = "400", description = "존재하지 않는 대학 시험입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
     @Operation(summary = "시험 보기: 문제지 [페이지네이션]", description = "시험 응시 화면의 문제지를 조회합니다.")
     ResponseEntity<SuccessResponse<Page<UniversityExamImageResponseDTO>>> getUniversityExamImages(
             @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long id,
-            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "문제 이미지 페이지 번호 -1") @RequestParam(defaultValue = "0") int page,
             Pageable pageable);
 
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "대학 시험 이미지 및 해제 PDF 조회에 성공했습니다"),
+                    @ApiResponse(responseCode = "400", description = "존재하지 않는 대학 시험입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
     @Operation(summary= "해제: 문제이미지_해제PDF", description = "시험 문제 이미지 및 해제 PDF를 조회합니다.")
     ResponseEntity<SuccessResponse<UniversityExamImageAndAnswerResponseDTO>> getUniversityExamImageAndAnswer(
             @PathVariable("id") Long universityExamId);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityApi.java
@@ -45,7 +45,7 @@ public interface UniversityApi {
 
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "200", description = "대학 시험 이미지 및 해제 PDF 조회에 성공했습니다"),
+                    @ApiResponse(responseCode = "201", description = "대학 시험 이미지 및 해제 PDF 조회에 성공했습니다"),
                     @ApiResponse(responseCode = "400", description = "존재하지 않는 대학 시험입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamImageAndAnswerResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamImageAndAnswerResponseDTO.java
@@ -1,9 +1,14 @@
 package com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(name = "UniversityExamImageAndAnswerResponseDTO", description = "대학시험 문제이미지_해제PDF 조회 요청 DTO")
 public record UniversityExamImageAndAnswerResponseDTO(
-        String universityExamName, List<UniversityExamImageResponseDTO> examQuestionList, String examAnswerUrl
+        @Schema(description = "시험 이름(대학 + 시험 년도 + 시험 이름)", example = "2023 중앙대학교 경영경제 1") String universityExamName,
+        @Schema(description = "시험 문제 이미지 리스트") List<UniversityExamImageResponseDTO> examQuestionList,
+        @Schema(description = "이미지 해제 PDF URL") String examAnswerUrl
 ) {
     static public UniversityExamImageAndAnswerResponseDTO of(String universityExamName,
                                                              List<UniversityExamImageResponseDTO> examQuestionList,

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamImageResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamImageResponseDTO.java
@@ -1,6 +1,9 @@
 package com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response;
 
-public record UniversityExamImageResponseDTO(String examImgUrl) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "UniversityExamImageResponseDTO", description = "대학 시험 이미지 조회 요청 DTO")
+public record UniversityExamImageResponseDTO(@Schema(description = "시험 문제 이미지 URL") String examImgUrl) {
     static public UniversityExamImageResponseDTO of(String examImgUrl) {
         return new UniversityExamImageResponseDTO(examImgUrl);
     }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamInfoResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamInfoResponseDTO.java
@@ -1,6 +1,10 @@
 package com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response;
 
-public record UniversityExamInfoResponseDTO(Long examId, String examName, int examTimeLimit) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UniversityExamInfoResponseDTO(@Schema(description = "시험 id", example = "1") Long examId,
+                                            @Schema(description = "시험 이름(대학 + 시험 년도 + 시험 이름)", example = "건국대학교 - 2021 인문사회 1") String examName,
+                                            @Schema(description = "시험 제한 시간 (초)", example = "6000") int examTimeLimit) {
     public static UniversityExamInfoResponseDTO of(Long examId, String examName, int examTimeLimit) {
         return new UniversityExamInfoResponseDTO(examId, examName, examTimeLimit);
     }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/entity/UniversityExam.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/entity/UniversityExam.java
@@ -17,7 +17,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class UniversityExam {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/entity/UniversityExamImage.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/entity/UniversityExamImage.java
@@ -16,7 +16,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class UniversityExamImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/exception/UniversityExamExceptionType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/exception/UniversityExamExceptionType.java
@@ -8,10 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum UniversityExamExceptionType implements ExceptionType {
 
-    /**
-     * 404 Not Found
-     */
-    NOT_FOUND_UNIVERSITY_EXAM(HttpStatus.NOT_FOUND, "존재하지 않는 대학 시험입니다."),
+    INVALID_UNIVERSITY_EXAM(HttpStatus.BAD_REQUEST, "존재하지 않는 대학 시험입니다."),
     NOT_FOUND_UNIVERSITY_EXAM_IMAGE(HttpStatus.NOT_FOUND, "존재하지 않는 대학 시험 입니다.");
 
     private final HttpStatus status;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/exception/UniversityExamExceptionType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/exception/UniversityExamExceptionType.java
@@ -8,8 +8,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum UniversityExamExceptionType implements ExceptionType {
 
+    /**
+     * 404 Not Found
+     */
     INVALID_UNIVERSITY_EXAM(HttpStatus.BAD_REQUEST, "존재하지 않는 대학 시험입니다."),
-    NOT_FOUND_UNIVERSITY_EXAM_IMAGE(HttpStatus.NOT_FOUND, "존재하지 않는 대학 시험 입니다.");
+    NOT_FOUND_UNIVERSITY_EXAM_IMAGE(HttpStatus.NOT_FOUND, "존재하지 않는 대학 시험 이미지 입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/service/UniversityExamService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/service/UniversityExamService.java
@@ -33,7 +33,7 @@ public class UniversityExamService {
     public UniversityExamInfoResponseDTO getUniversityExam(Long universityExamId) {
         UniversityExam universityExam = universityExamRepository.findByUniversityExamId(universityExamId)
                 .orElseThrow(() -> new UniversityExamException(
-                        UniversityExamExceptionType.NOT_FOUND_UNIVERSITY_EXAM));
+                        UniversityExamExceptionType.INVALID_UNIVERSITY_EXAM));
         String universityExamName = universityExam.getUniversityExamFullName();
         return UniversityExamInfoResponseDTO.of(universityExam.getUniversityExamId(),
                 universityExamName,
@@ -43,7 +43,7 @@ public class UniversityExamService {
     public Page<UniversityExamImageResponseDTO> getUniversityExamImages(Long id, Pageable pageable) {
         UniversityExam universityExam = universityExamRepository.findByUniversityExamId(id)
                 .orElseThrow(() -> new UniversityExamException(
-                        UniversityExamExceptionType.NOT_FOUND_UNIVERSITY_EXAM));
+                        UniversityExamExceptionType.INVALID_UNIVERSITY_EXAM));
         Page<UniversityExamImage> universityExamImages = universityExamImageRepository.findAllByUniversityExamOrderByPageAsc(
                 universityExam,
                 pageable);
@@ -55,7 +55,7 @@ public class UniversityExamService {
     public UniversityExamImageAndAnswerResponseDTO getUniversityExamImageAndAnswer(Long universityExamId) {
         UniversityExam universityExam = universityExamRepository.findByUniversityExamId(universityExamId)
                 .orElseThrow(() -> new UniversityExamException(
-                        UniversityExamExceptionType.NOT_FOUND_UNIVERSITY_EXAM));
+                        UniversityExamExceptionType.INVALID_UNIVERSITY_EXAM));
 
         String examAnswerUrl = cloudFrontService.createPreSignedGetUrl(EXAM_ANSWER_FOLDER_NAME,
                 universityExam.getUniversityExamAnswerFileName());

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/UniversityExamRecordApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/UniversityExamRecordApi.java
@@ -6,11 +6,14 @@ import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller.
 import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller.dto.response.UniversityExamRecordResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller.dto.response.UniversityExamRecordResultResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller.dto.response.UniversityExamSheetPreSignedUrlResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.global.response.ErrorResponse;
 import com.nonsoolmate.nonsoolmateServer.global.response.SuccessResponse;
 import com.nonsoolmate.nonsoolmateServer.global.security.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -24,27 +27,46 @@ public interface UniversityExamRecordApi {
 
     @ApiResponses(
             value = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", content = @Content),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", content = @Content)
+                    @ApiResponse(responseCode = "200", description = "첨삭 PDF, 해제 PDF 조회에 성공했습니다."),
+                    @ApiResponse(responseCode = "400", description = "존재하지 않는 대학 시험입니다, 첨삭이 완료되지 않았습니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 시험 응시 기록입니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
-
     @Operation(summary = "첨삭: 첨삭 PDF_해제PDF", description = "첨삭 pdf 및 해제 pdf를 조회합니다.")
     ResponseEntity<SuccessResponse<UniversityExamRecordResponseDTO>> getUniversityExamRecord(
             @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long universityExamId,
             @AuthUser Member member);
 
+
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "첨삭 PDF 조회에 성공했습니다."),
+                    @ApiResponse(responseCode = "400", description = "존재하지 않는 대학 시험입니다, 첨삭이 완료되지 않았습니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 시험 응시 기록입니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
     @Operation(summary = "첨삭: 첨삭 PDF 저장", description = "첨삭 pdf를 조회합니다.")
     ResponseEntity<SuccessResponse<UniversityExamRecordResultResponseDTO>> getUniversityExamRecordResult(
             @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long universityExamId,
             @AuthUser Member member);
 
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "답안지 업로드 PresignedUrl 발급에 성공했습니다.")
+            }
+    )
     @Operation(summary = "시험 보기: [1] 답안지 업로드 PresignedUrl 조회 API", description = "답안지(시험응시기록) 업로드를 위한 PresignedUrl를 조회합니다.")
     ResponseEntity<SuccessResponse<UniversityExamSheetPreSignedUrlResponseDTO>> getUniversityExamSheetPreSignedUrl();
 
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "201", description = "대학 시험 기록에 성공했습니다."),
+                    @ApiResponse(responseCode = "400", description = "존재하지 않는 대학 시험입니다, 이미 응시한 대학 시험입니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 답안지 파일 이름을 찾을 수 없습니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
     @Operation(summary = "시험보기: [3] 답안지 업로드 후 시험 기록 API", description = "답안지(시험응시기록) 업로드 후 서버에 기록하기 위해 호출합니다.")
     ResponseEntity<SuccessResponse<UniversityExamRecordIdResponse>> createUniversityExamRecord(
-            @Parameter(description = "해당 대학교 시험 Id (examId), 시험 응시 소요 시간, 답안지(응시 기록) 파일 이름", required = true) @Valid @RequestBody CreateUniversityExamRequestDTO createUniversityExamRequestDTO,
+            @Valid @RequestBody CreateUniversityExamRequestDTO createUniversityExamRequestDTO,
             @AuthUser Member member);
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/dto/request/CreateUniversityExamRequestDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/dto/request/CreateUniversityExamRequestDTO.java
@@ -1,11 +1,13 @@
 package com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
-public record CreateUniversityExamRequestDTO(@NotNull Long universityExamId,
-                                             @Positive int memberTakeTimeExam,
-                                             @NotNull String memberSheetFileName) {
+@Schema(name = "CreateUniversityExamRequestDTO", description = "대학 시험 기록 생성 요청 DTO")
+public record CreateUniversityExamRequestDTO(@NotNull @Schema(description = "대학 시험 id", example="1") Long universityExamId,
+                                             @Positive @Schema(description = "사용자가 해당 시험을 보는데 걸린 시간(초 단위)") int memberTakeTimeExam,
+                                             @NotNull @Schema(description="PreSingedUrl 발급 시 전달 받은 파일 이름") String memberSheetFileName) {
     public static CreateUniversityExamRequestDTO of(Long universityExamId, int memberTakeTimeExam,
                                                     String memberSheetFileName) {
         return new CreateUniversityExamRequestDTO(universityExamId, memberTakeTimeExam, memberSheetFileName);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/dto/response/UniversityExamRecordIdResponse.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/dto/response/UniversityExamRecordIdResponse.java
@@ -1,6 +1,10 @@
 package com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller.dto.response;
 
-public record UniversityExamRecordIdResponse(Long universityExamRecordId) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "UniversityExamRecordIdResponse", description = "대학 시험 기록 생성 응답 DTO")
+public record UniversityExamRecordIdResponse(
+        @Schema(description = "기록된 대학 시험 답안 id", example = "1") Long universityExamRecordId) {
     public static UniversityExamRecordIdResponse of(Long universityExamRecordId) {
         return new UniversityExamRecordIdResponse(universityExamRecordId);
     }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/dto/response/UniversityExamRecordResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/dto/response/UniversityExamRecordResponseDTO.java
@@ -1,9 +1,12 @@
 package com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "UniversityExamRecordResponseDTO", description = "첨삭 PDF_해제PDF 조회 응답 DTO")
 public record UniversityExamRecordResponseDTO(
-        String universityExamName,
-        String examAnswerUrl,
-        String examResultUrl
+        @Schema(description = "시험 이름(대학이름+시험년도+시험이름)", example = "건국대학교 - 2021 인문사회 2") String universityExamName,
+        @Schema(description = "시험 해제 PDF URL", example = "1") String examAnswerUrl,
+        @Schema(description = "시험 첨삭 결과 PDF URL", example = "1") String examResultUrl
 ) {
     public static UniversityExamRecordResponseDTO of(String universityExamName, String examAnswerUrl, String examResultUrl) {
         return new UniversityExamRecordResponseDTO(universityExamName, examAnswerUrl, examResultUrl);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/dto/response/UniversityExamRecordResultResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/dto/response/UniversityExamRecordResultResponseDTO.java
@@ -1,7 +1,10 @@
 package com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "UniversityExamRecordResultResponseDTO", description = "첨삭 PDF 저장 응답 DTO")
 public record UniversityExamRecordResultResponseDTO(
-        String examResultUrl
+        @Schema(description = "첨삭 결과 PDF URL") String examResultUrl
 ) {
     public static UniversityExamRecordResultResponseDTO of(String examResultUrl) {
         return new UniversityExamRecordResultResponseDTO(examResultUrl);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/dto/response/UniversityExamSheetPreSignedUrlResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/controller/dto/response/UniversityExamSheetPreSignedUrlResponseDTO.java
@@ -1,7 +1,12 @@
 package com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.controller.dto.response;
 
-public record UniversityExamSheetPreSignedUrlResponseDTO(String resultFileName, String preSignedUrl) {
-    static public UniversityExamSheetPreSignedUrlResponseDTO of(String resultFileName, String preSignedUrl) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "UniversityExamSheetPreSignedUrlResponseDTO", description = "답안지 업로드 PresignedUrl 조회 응답 DTO")
+public record UniversityExamSheetPreSignedUrlResponseDTO(
+        @Schema(description = "시험보기: [3] 답안지 업로드 후 시험 기록 API 에서 다시 서버로 보내야하는 파일 이름") String resultFileName,
+        @Schema(description = "시험보기: [2] 답안지 업로드 API를 요청할 URL") String preSignedUrl) {
+    public static UniversityExamSheetPreSignedUrlResponseDTO of(String resultFileName, String preSignedUrl) {
         return new UniversityExamSheetPreSignedUrlResponseDTO(resultFileName, preSignedUrl);
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/service/UniversityExamRecordService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/service/UniversityExamRecordService.java
@@ -1,6 +1,6 @@
 package com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.service;
 
-import static com.nonsoolmate.nonsoolmateServer.domain.university.exception.UniversityExamExceptionType.NOT_FOUND_UNIVERSITY_EXAM;
+import static com.nonsoolmate.nonsoolmateServer.domain.university.exception.UniversityExamExceptionType.INVALID_UNIVERSITY_EXAM;
 import static com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.exception.UniversityExamRecordExceptionType.*;
 import static com.nonsoolmate.nonsoolmateServer.external.aws.FolderName.*;
 
@@ -18,7 +18,6 @@ import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.entity.Univ
 import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.entity.enums.ExamResultStatus;
 import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.exception.UniversityExamRecordException;
 import com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.repository.UniversityExamRecordRepository;
-import com.nonsoolmate.nonsoolmateServer.external.aws.error.AWSBusinessException;
 import com.nonsoolmate.nonsoolmateServer.external.aws.error.AWSClientException;
 import com.nonsoolmate.nonsoolmateServer.external.aws.service.CloudFrontService;
 import com.nonsoolmate.nonsoolmateServer.external.aws.service.S3Service;
@@ -121,7 +120,7 @@ public class UniversityExamRecordService {
 
     private UniversityExam getUniversityExam(Long universityExamId) {
         return universityExamRepository.findByUniversityExamId(universityExamId)
-                .orElseThrow(() -> new UniversityExamException(NOT_FOUND_UNIVERSITY_EXAM));
+                .orElseThrow(() -> new UniversityExamException(INVALID_UNIVERSITY_EXAM));
     }
 
     private UniversityExamRecord getUniversityExamByUniversityExamAndMember(UniversityExam universityExam,


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#106 -> dev
- closed #106


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 각 컨트롤러별로 성공 케이스, 에러 케이스에 대하여 ApiResponse를 추가해주었습니다
- Response, Request DTO에도 각 필드 별로 설명을 추가하였습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="812" alt="image" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/c6f79be5-ba7f-4c9f-ab83-1c9fac38bada">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
