### PR TITLE
[FIX] reissue 로직 수정 및 목표대학 응답코드 수정

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/AuthApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/AuthApi.java
@@ -37,7 +37,7 @@ public interface AuthApi {
     @ApiResponses(
             value = {
                     @ApiResponse(responseCode = "200", description = "리프레시 토큰 재발급에 성공하였습니다."),
-                    @ApiResponse(responseCode = "400", description = "서비스에서 발급되지 않은 리프레시 토큰입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "서비스에서 발급되지 않거나 이미 사용된 리프레시 토큰입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "401", description = "기한이 만료된 리프레시 토큰입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/exception/AuthExceptionType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/exception/AuthExceptionType.java
@@ -14,7 +14,7 @@ public enum AuthExceptionType implements ExceptionType {
     INVALID_MEMBER_PLATFORM_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 플랫폼 인가코드입니다."),
     INVALID_PLATFORM_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 플랫폼 유형입니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "서비스에서 발급되지 않은 액세스 토큰입니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "서비스에서 발급되지 않은 리프레시 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "서비스에서 발급되지 않거나 이미 사용된 리프레시 토큰입니다."),
 
     /**
      * 401 Unauthorized

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/exception/SelectUniversitySuccessType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/exception/SelectUniversitySuccessType.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum SelectUniversitySuccessType implements SuccessType {
     GET_SELECT_UNIVERSITIES_SUCCESS(HttpStatus.OK, "목표 대학 조회에 성공하였습니다."),
     GET_SELECT_UNIVERSITY_EXAMS_SUCCESS(HttpStatus.OK, "목표 대학 시험 리스트 조회에 성공하였습니다."),
-    PATCH_SELECT_UNIVERSITIES_SUCCESS(HttpStatus.CREATED, "목표 대학 수정에 성공하였습니다.");
+    PATCH_SELECT_UNIVERSITIES_SUCCESS(HttpStatus.OK, "목표 대학 수정에 성공하였습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/redis/repository/RedisTokenRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/redis/repository/RedisTokenRepository.java
@@ -17,7 +17,6 @@ public interface RedisTokenRepository extends CrudRepository<RefreshTokenVO, Str
 
     default RefreshTokenVO findByMemberIdOrElseThrowException(String memberId) {
         return findByMemberId(memberId)
-                .filter(refreshTokenVO -> !refreshTokenVO.isBlack())
                 .orElseThrow(
                 () -> new AuthException(UNAUTHORIZED_REFRESH_TOKEN));
     }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/service/JwtTokenProvider.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/service/JwtTokenProvider.java
@@ -45,11 +45,12 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String createRefreshToken(Long expirationTime) {
+    public String createRefreshToken(Long memberId, Long expirationTime) {
         Date now = new Date();
 
         return Jwts.builder()
                 .setSubject(REFRESH_TOKEN_SUBJECT)
+                .claim(MEMBER_ID_CLAIM, memberId)
                 .setIssuedAt(now)   //토큰 발행 시간 정보
                 .setExpiration(new Date(now.getTime() + expirationTime))  //토큰 만료 시간 설정
                 .signWith(key, SignatureAlgorithm.HS256)

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/service/vo/RefreshTokenVO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/service/vo/RefreshTokenVO.java
@@ -17,8 +17,6 @@ public class RefreshTokenVO {
     @Indexed
     private String memberId;
 
-    private boolean black;
-
     private String refreshToken;
 
 
@@ -26,14 +24,9 @@ public class RefreshTokenVO {
         this.refreshToken = refreshToken;
     }
 
-    public void updateBlack(boolean black) {
-        this.black = black;
-    }
-
     @Builder
-    public RefreshTokenVO(String memberId, boolean black, String refreshToken) {
+    public RefreshTokenVO(String memberId, String refreshToken) {
         this.memberId = memberId;
-        this.black = black;
         this.refreshToken = refreshToken;
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/security/config/SecurityConfig.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/security/config/SecurityConfig.java
@@ -23,17 +23,26 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private static final String[] AUTH_WHITELIST = {
-            "/", "/error", "/webjars/**",
+    public static final String[] AUTH_WHITELIST = {
+            "/", "/error",
+
+             "/favicon.ico",
+
+            "/actuator/health", "/check/profile"
+    };
+
+    public static final String[] AUTH_WHITELIST_WILDCARD = {
+            "/webjars/**",
 
             "/swagger-resources/**",
             "/swagger-ui/**",
             "/v3/api-docs/**",
             "/webjars/**",
+            "/auth/**", "/login/**",
 
-            "/auth/**", "/login/**", "/authTest",
+            "/css/**", "/images/**", "/js/**",
 
-            "/", "/css/**", "/images/**", "/js/**", "/favicon.ico", "/h2-console/**", "/actuator/health", "/check/profile"
+            "/h2-console/**",
     };
 
     @Value("${spring.web.domain.server}")
@@ -86,6 +95,7 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(auth -> {
                     auth.requestMatchers(AUTH_WHITELIST).permitAll();
+                    auth.requestMatchers(AUTH_WHITELIST_WILDCARD).permitAll();
                     auth.anyRequest().authenticated();
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/security/filter/JwtAuthenticationFilter.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/security/filter/JwtAuthenticationFilter.java
@@ -3,18 +3,22 @@ package com.nonsoolmate.nonsoolmateServer.global.security.filter;
 
 import static com.nonsoolmate.nonsoolmateServer.domain.auth.exception.AuthExceptionType.INVALID_ACCESS_TOKEN;
 import static com.nonsoolmate.nonsoolmateServer.domain.auth.exception.AuthExceptionType.UNAUTHORIZED_ACCESS_TOKEN;
+import static com.nonsoolmate.nonsoolmateServer.global.security.config.SecurityConfig.AUTH_WHITELIST;
+import static com.nonsoolmate.nonsoolmateServer.global.security.config.SecurityConfig.AUTH_WHITELIST_WILDCARD;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nonsoolmate.nonsoolmateServer.domain.auth.exception.AuthException;
 import com.nonsoolmate.nonsoolmateServer.global.jwt.service.JwtService;
 import com.nonsoolmate.nonsoolmateServer.global.security.service.MemberAuthService;
 import com.nonsoolmate.nonsoolmateServer.global.jwt.utils.RequestUtils;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -36,17 +40,28 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
+        if (Arrays.stream(AUTH_WHITELIST)
+                .anyMatch(whiteUrl -> request.getRequestURI().equals(whiteUrl))) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (Arrays.stream(AUTH_WHITELIST_WILDCARD)
+                .anyMatch(
+                        whiteUrl -> request.getRequestURI().startsWith(whiteUrl.substring(0, whiteUrl.length() - 3)))) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         if (!RequestUtils.isContainsAccessToken(request)) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        String authorizationAccessToken = RequestUtils.getAuthorizationAccessToken((HttpServletRequest) request);
+        String authorizationAccessToken = RequestUtils.getAuthorizationAccessToken(request);
 
         try {
-            if (!jwtService.validateToken(authorizationAccessToken)) {
-                throw new AuthException(UNAUTHORIZED_ACCESS_TOKEN);
-            }
+            jwtService.validateToken(authorizationAccessToken);
 
             Long memberId = jwtService.extractMemberIdFromAccessToken(authorizationAccessToken);
             UserDetails userDetails = memberAuthService.loadUserByUsername(String.valueOf(memberId));
@@ -56,9 +71,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.info("Authentication Principal : {}", authentication.getPrincipal().toString());
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        } catch (JsonProcessingException e) {
+        } catch (JsonProcessingException | MalformedJwtException e) {
             throw new AuthException(INVALID_ACCESS_TOKEN);
-        } catch (AuthException e) {
+        } catch (ExpiredJwtException e){
+            throw new AuthException(UNAUTHORIZED_ACCESS_TOKEN);
+        }
+        catch (AuthException e) {
             throw new AuthException(e.getExceptionType());
         }
 


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/#124 -> dev
- closed #124 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- reissue 로직 수정
- jwtfilter에 whitelist 검증 로직 추가
- 리프레시 토큰에 memberId 클레임 추가
- validateToken 예외 처리 방식 변경
- 목표대학 patch 응답 코드 수정 201 -> 200로 수정

## 📝 테스트 결과
<!-- local에서 postman으
로 요청한 결과를 첨부합니다 -->
<img width="899" alt="스크린샷 2024-01-18 오전 4 41 24" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/100754581/cd832d86-dbb2-4f08-a30c-e707c2aabde5">

<img width="851" alt="스크린샷 2024-01-18 오전 4 41 50" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/100754581/72537600-30bf-4933-9ed1-64cac63e8cbd">

<img width="861" alt="스크린샷 2024-01-18 오전 4 40 19" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/100754581/fd676f4d-ce71-4582-8453-d67c1d40a35f">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
1. jwtfilter 변경 : 재발행일 때, 다음필터로 넘어가야 하는데 분기처리가 되지 않은게 문제였습니다! 레퍼런스를 찾아보니 가장 안전한 방식은 whiteList인지 확인하는 로직을 필터 메서드 가장 상단에 놓는게 좋은거 같아 그렇게 구현했습니다.

2. Jwts 라이브러리 사용하면, 액세스 토큰의 만료시간이 지나면 아예 멤버 Id(클레임)를 추출할 수 없다는 사실을 몰랐습니다.. 따라서 reissue하기 위해선 오직 리프레시 토큰만 사용해야 함을 알게 되었습니다. 그래서 레퍼런스를 찾아본 후, 결국 리프레시 토큰에 memberId 클레임을 추가했는데 이에 대한 의견이 궁금합니다!

3. validateToken이 액세스&라프레시 토큰 모두 사용되기에 예외 처리의 위치를 변경했는데요! 이에 대한 의견이 궁금합니다!