### PR TITLE
[FEAT] Bearer 토큰 내용 오류 예외 처리 추가

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/service/JwtService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/service/JwtService.java
@@ -18,6 +18,7 @@ import com.nonsoolmate.nonsoolmateServer.global.jwt.service.vo.RefreshTokenVO;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Date;
 import java.util.Optional;
@@ -74,7 +75,7 @@ public class JwtService {
 
         try {
             validateToken(refreshToken);
-        } catch (MalformedJwtException e) {
+        } catch (MalformedJwtException | SignatureException e) {
             throw new AuthException(INVALID_REFRESH_TOKEN);
         } catch (ExpiredJwtException e){
             throw new AuthException(UNAUTHORIZED_REFRESH_TOKEN);
@@ -106,7 +107,7 @@ public class JwtService {
         return jwtTokenProvider.getMemberIdFromClaim(tokenClaims, AUTH_USER);
     }
 
-    public Boolean validateToken(final String atk) throws ExpiredJwtException, MalformedJwtException {
+    public Boolean validateToken(final String atk) throws ExpiredJwtException, MalformedJwtException, SignatureException {
         Claims tokenClaims = jwtTokenProvider.getTokenClaims(atk);
         return !tokenClaims.getExpiration().before(new Date());
     }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/security/filter/JwtAuthenticationFilter.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/security/filter/JwtAuthenticationFilter.java
@@ -13,6 +13,7 @@ import com.nonsoolmate.nonsoolmateServer.global.security.service.MemberAuthServi
 import com.nonsoolmate.nonsoolmateServer.global.jwt.utils.RequestUtils;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -71,7 +72,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.info("Authentication Principal : {}", authentication.getPrincipal().toString());
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        } catch (JsonProcessingException | MalformedJwtException e) {
+        } catch (JsonProcessingException | MalformedJwtException | SignatureException e) {
             throw new AuthException(INVALID_ACCESS_TOKEN);
         } catch (ExpiredJwtException e){
             throw new AuthException(UNAUTHORIZED_ACCESS_TOKEN);


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#128 -> dev
- closed #128 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 문제 상황 : 클라측에서의 Bearer ehqhfuq~~~ 가 아닌 Bearer "ehqhfuq~~~"로 보낼 경우 서버 에러를 반환하는 에러가 있었습니다.
- 해결 : 따라서 토큰 내용 오류 예외 처리 추가를 했습니다!

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="859" alt="스크린샷 2024-01-18 오후 4 52 51" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/100754581/a46c6d17-5546-460a-a949-8b13a69229c7">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
