### PR TITLE
[FIX] MethodArgumentTypeMismatchException 처리 및 디스코드 버그 해결

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/discord/DiscordAppender.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/discord/DiscordAppender.java
@@ -11,11 +11,13 @@ import com.nonsoolmate.nonsoolmateServer.global.util.MDCUtil;
 import com.nonsoolmate.nonsoolmateServer.global.util.StringUtil;
 import io.micrometer.core.instrument.util.StringEscapeUtils;
 import com.nonsoolmate.nonsoolmateServer.external.discord.model.EmbedObject;
+
 import java.awt.Color;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
+
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -59,52 +61,16 @@ public class DiscordAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             exceptionBrief = "EXCEPTION 정보가 남지 않았습니다.";
         }
 
-        discordWebhook.addEmbed(new EmbedObject()
-                .setTitle("[" + level + " - 문제 간략 내용]")
-                .setColor(messageColor)
-                .setDescription(exceptionBrief)
-                .addField("[" + "Exception Level" + "]",
-                        StringEscapeUtils.escapeJson(level),
-                        true)
-                .addField("[문제 발생 시각]",
-                        LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
-                        false)
-                .addField(
-                        "[" + MDCUtil.REQUEST_URI_MDC + "]",
-                        StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCUtil.REQUEST_URI_MDC)),
-                        false)
-                .addField(
-                        "[" + MDCUtil.USER_IP_MDC + "]",
-                        StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCUtil.USER_IP_MDC)),
-                        false)
-                .addField(
-                        "[" + MDCUtil.HEADER_MAP_MDC + "]",
-                        StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCUtil.HEADER_MAP_MDC).replaceAll("[\\{\\{\\}]", "")),
-                        true)
-                .addField(
-                        "[" + MDCUtil.USER_REQUEST_COOKIES + "]",
-                        StringEscapeUtils.escapeJson(
-                                mdcPropertyMap.get(MDCUtil.USER_REQUEST_COOKIES).replaceAll("[\\{\\{\\}]", "")),
-                        false)
-                .addField(
-                        "[" + MDCUtil.PARAMETER_MAP_MDC + "]",
-                        StringEscapeUtils.escapeJson(
-                                mdcPropertyMap.get(MDCUtil.PARAMETER_MAP_MDC).replaceAll("[\\{\\{\\}]", "")),
-                        false)
-                .addField("[" + MDCUtil.BODY_MDC + "]",
-                        StringEscapeUtils.escapeJson(StringUtil.translateEscapes(mdcPropertyMap.get(MDCUtil.BODY_MDC))),
-                        false)
-        );
+        if (exceptionBrief.length() > 183) {
+            exceptionBrief = exceptionBrief.substring(0, 183);
+        }
+
+        discordWebhook.addEmbed(new EmbedObject().setTitle("[" + level + " - 문제 간략 내용]").setColor(messageColor).setDescription(exceptionBrief).addField("[" + "Exception Level" + "]", StringEscapeUtils.escapeJson(level), true).addField("[문제 발생 시각]", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")), false).addField("[" + MDCUtil.REQUEST_URI_MDC + "]", StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCUtil.REQUEST_URI_MDC)), false).addField("[" + MDCUtil.USER_IP_MDC + "]", StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCUtil.USER_IP_MDC)), false).addField("[" + MDCUtil.HEADER_MAP_MDC + "]", StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCUtil.HEADER_MAP_MDC).replaceAll("[\\{\\{\\}]", "")), true).addField("[" + MDCUtil.USER_REQUEST_COOKIES + "]", StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCUtil.USER_REQUEST_COOKIES).replaceAll("[\\{\\{\\}]", "")), false).addField("[" + MDCUtil.PARAMETER_MAP_MDC + "]", StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCUtil.PARAMETER_MAP_MDC).replaceAll("[\\{\\{\\}]", "")), false).addField("[" + MDCUtil.BODY_MDC + "]", StringEscapeUtils.escapeJson(StringUtil.translateEscapes(mdcPropertyMap.get(MDCUtil.BODY_MDC))), false));
 
         if (throwable != null) {
             exceptionDetail = ThrowableProxyUtil.asString(throwable);
             String exception = exceptionDetail.substring(0, 4000);
-            discordWebhook.addEmbed(
-                    new EmbedObject()
-                            .setTitle("[Exception 상세 내용]")
-                            .setColor(messageColor)
-                            .setDescription(StringEscapeUtils.escapeJson(exception))
-            );
+            discordWebhook.addEmbed(new EmbedObject().setTitle("[Exception 상세 내용]").setColor(messageColor).setDescription(StringEscapeUtils.escapeJson(exception)));
         }
 
         try {

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/discord/DiscordWebHook.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/discord/DiscordWebHook.java
@@ -40,15 +40,11 @@ public class DiscordWebHook {
             throw new RuntimeException("컨텐츠를 설정하거나 하나 이상의 Embed Object를 추가해야 합니다.");
         }
 
-        try {
-            ApiCallUtil.callDiscordAppenderPostAPI(
-                    this.urlString, createDiscordEmbedObject(
-                            this.embeds, initializerDiscordSendForJsonObject(new JsonObject())
-                    ));
+        ApiCallUtil.callDiscordAppenderPostAPI(
+                this.urlString, createDiscordEmbedObject(
+                        this.embeds, initializerDiscordSendForJsonObject(new JsonObject())
+                ));
 
-        } catch (IOException ioException) {
-            throw ioException;
-        }
     }
 
     private JsonObject initializerDiscordSendForJsonObject(JsonObject json) {

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/error/GlobalExceptionHandler.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/error/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 @RestControllerAdvice
@@ -56,6 +57,11 @@ public class GlobalExceptionHandler {
         }
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(CommonErrorType.INVALID_INPUT_VALUE, builder.toString()));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException ex){
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(CommonErrorType.INVALID_INPUT_VALUE, ex.getMessage()));
     }
 
     @ExceptionHandler(HttpMediaTypeNotSupportedException.class)

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/logging/filter/ServletWrappingFilter.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/logging/filter/ServletWrappingFilter.java
@@ -1,6 +1,5 @@
 package com.nonsoolmate.nonsoolmateServer.global.logging.filter;
 
-import com.nonsoolmate.nonsoolmateServer.global.logging.filter.CachedBodyRequestWrapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/util/ApiCallUtil.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/util/ApiCallUtil.java
@@ -1,35 +1,34 @@
 package com.nonsoolmate.nonsoolmateServer.global.util;
 
 import com.nonsoolmate.nonsoolmateServer.external.discord.model.JsonObject;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.net.URL;
-import javax.net.ssl.HttpsURLConnection;
+
+import io.jsonwebtoken.io.IOException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 @Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApiCallUtil {
 
-    public static void callDiscordAppenderPostAPI(String urlString, JsonObject json) throws IOException {
-        URL url = new URL(urlString);
-        HttpsURLConnection connection = (HttpsURLConnection)url.openConnection();
-        connection.addRequestProperty("Content-Type", "application/json");
-        connection.addRequestProperty("User-Agent", "Java-DiscordWebhook-BY-Gelox_");
-        connection.setDoOutput(true);
-        connection.setRequestMethod("POST");
-
-        try (OutputStream stream = connection.getOutputStream()) {
-            stream.write(json.toString().getBytes());
-            stream.flush();
-
-            connection.getInputStream().close();
-            connection.disconnect();
-
-        } catch (IOException ioException) {
-            throw ioException;
+    public static void callDiscordAppenderPostAPI(String urlString, JsonObject json) {
+        WebClient webClient = WebClient.create();
+        try {
+            webClient.post()
+                    .uri(urlString)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("User-Agent", "Java-DiscordWebhook-BY-Gelox_")
+                    .body(Mono.just(json.toString()), String.class)
+                    .retrieve()
+                    .bodyToMono(Void.class)
+                    .block();
+        } catch (IOException e) {
+            log.error("Discord Appender API 호출 실패", e.getMessage());
+            throw e;
         }
     }
 }
+


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/#130 -> dev
- closed #130


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- MethodArgumentTypeMismatchException을 핸들링하지 않아 서버 500에러로 인식되는 문제를 해결했습니다
- 처음에 서버 500 에러를 디스코드 봇이 인식 못한다고 판단했는데 그게 아니라 `discordWebhook.addEmbed`에서 setDiscription 함수 인자로 들어가는 String의 길이가 183자를 넘어가면 디스코드 봇에서 서버 에러를 메시지로 발송하지 않는 문제를 발견하여 이를 처리했습니다


## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![이미지 1-18-24 오후 11 58](https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/a85766f5-f8c1-451e-a30c-aa2648e5dbc4)


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 디버깅 천재: 송민규
