### PR TITLE
[FIX] 목표 대학 시험 리스트 조회에서 시험 년도를 기준으로 내림차순으로 정렬되도록 수정

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/service/SelectUniversityService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/service/SelectUniversityService.java
@@ -70,7 +70,7 @@ public class SelectUniversityService {
                                                                                  Member member) {
         List<SelectUniversityExamResponseDTO> selectUniversityExamResponseDTOS;
 
-        List<UniversityExam> universityExams = universityExamRepository.findAllByUniversity(
+        List<UniversityExam> universityExams = universityExamRepository.findAllByUniversityOrderByUniversityExamYearDesc(
                 selectUniversity.getUniversity());
 
         selectUniversityExamResponseDTOS = getSelectUniversityExamResponseDTOS(universityExams, member);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/repository/UniversityExamRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/repository/UniversityExamRepository.java
@@ -9,5 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UniversityExamRepository extends JpaRepository<UniversityExam, Long> {
     Optional<UniversityExam> findByUniversityExamId(Long universityId);
 
-    List<UniversityExam> findAllByUniversity(University university);
+    List<UniversityExam> findAllByUniversityOrderByUniversityExamYearDesc(University university);
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/#137 -> dev
- closed #137


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 대학 년도를 기준으로 내림차순 되도록 수정했습니다


## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="854" alt="image" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/4d8039fd-d6b2-4f15-aa52-68f132f603a4">



## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
