### PR TITLE
[FEAT] 답안지 업로드에서 S3 PreSignedUrl이 아닌 CloudFront PreSignedUrl을 통한 업로드 방식 구현

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/service/UniversityExamRecordSheetService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/universityExamRecord/service/UniversityExamRecordSheetService.java
@@ -2,7 +2,7 @@ package com.nonsoolmate.nonsoolmateServer.domain.universityExamRecord.service;
 
 import static com.nonsoolmate.nonsoolmateServer.external.aws.FolderName.EXAM_SHEET_FOLDER_NAME;
 
-import com.nonsoolmate.nonsoolmateServer.external.aws.service.S3Service;
+import com.nonsoolmate.nonsoolmateServer.external.aws.service.CloudFrontService;
 import com.nonsoolmate.nonsoolmateServer.external.aws.service.vo.PreSignedUrlVO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,10 +12,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UniversityExamRecordSheetService {
-    private final S3Service s3Service;
+    private final CloudFrontService cloudFrontService;
 
     public PreSignedUrlVO getUniversityExamRecordSheetPreSignedUrl() {
-        return s3Service.getUploadPreSignedUrl(EXAM_SHEET_FOLDER_NAME);
+        return cloudFrontService.createPreSignedPutUrl(EXAM_SHEET_FOLDER_NAME);
     }
 
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/aws/error/AWSExceptionType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/aws/error/AWSExceptionType.java
@@ -11,6 +11,8 @@ public enum AWSExceptionType implements ExceptionType {
     NOT_FOUND_AWS_PRIVATE_KEY(HttpStatus.NOT_FOUND, "해당 AWS Private Key를 찾을 수 없습니다"),
     NOT_FOUND_SHEET_FILE_AWS_S3(HttpStatus.NOT_FOUND, "해당 답안지 파일 이름을 찾을 수 없습니다"),
     GET_PRESIGNED_URL_AWS_CLOUDFRONT_FAIL(HttpStatus.BAD_REQUEST, "Cloud PreSignedUrl 발급에 실패했습니다"),
+
+    FAIL_ENCODING_FILE_NAME(HttpStatus.BAD_REQUEST, "파일 이름 인코딩에 실패했습니다"),
     AWS_S3_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "S3 서비스 에러");
 
     private final HttpStatus status;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/aws/service/CloudFrontService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/aws/service/CloudFrontService.java
@@ -2,12 +2,16 @@ package com.nonsoolmate.nonsoolmateServer.external.aws.service;
 
 import com.nonsoolmate.nonsoolmateServer.external.aws.error.AWSBusinessException;
 import com.nonsoolmate.nonsoolmateServer.external.aws.error.AWSExceptionType;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import com.nonsoolmate.nonsoolmateServer.external.aws.service.vo.PreSignedUrlVO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,9 +36,22 @@ public class CloudFrontService {
 
     private static final Long PRE_SIGNED_URL_EXPIRE_SECONDS = 30L;
 
+    public PreSignedUrlVO createPreSignedPutUrl(String path) {
+        String fileName = generateZipFileName();
+        return PreSignedUrlVO.of(fileName, createPreSignedUrl(path + fileName));
+    }
+
+    private String generateZipFileName() {
+        return UUID.randomUUID() + ".zip";
+    }
+
     public String createPreSignedGetUrl(String path, String fileName) {
+        String resourcePath = getEncodedResourcePath(path, fileName);
+        return createPreSignedUrl(resourcePath);
+    }
+
+    private String createPreSignedUrl(String resourcePath) {
         try {
-            String resourcePath = getEncodedResourcePath(path, fileName);
             String cloudFrontUrl = "https://" + distributionDomain + "/" + resourcePath;
             Instant expirationTime = Instant.now().plus(PRE_SIGNED_URL_EXPIRE_SECONDS, ChronoUnit.SECONDS);
             Path keyPath = Paths.get(privateKeyFilePath);
@@ -48,15 +65,19 @@ public class CloudFrontService {
                     .build();
             SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCannedPolicy(cannedSignerRequest);
             return signedUrl.url();
-        } catch(AWSBusinessException e){
+        } catch (AWSBusinessException e) {
             throw new AWSBusinessException(AWSExceptionType.GET_PRESIGNED_URL_AWS_CLOUDFRONT_FAIL);
         } catch (Exception e) {
             throw new AWSBusinessException(AWSExceptionType.NOT_FOUND_AWS_PRIVATE_KEY);
         }
     }
 
-    private String getEncodedResourcePath(String path, String fileName) throws UnsupportedEncodingException {
-        String encodedFileName = URLEncoder.encode(fileName, "UTF-8");
-        return path + encodedFileName;
+    private String getEncodedResourcePath(String path, String fileName) {
+        try {
+            String encodedFileName = URLEncoder.encode(fileName, "UTF-8");
+            return path + encodedFileName;
+        } catch (UnsupportedEncodingException e) {
+            throw new AWSBusinessException(AWSExceptionType.FAIL_ENCODING_FILE_NAME);
+        }
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/aws/service/S3Service.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/aws/service/S3Service.java
@@ -2,9 +2,7 @@ package com.nonsoolmate.nonsoolmateServer.external.aws.service;
 
 import com.nonsoolmate.nonsoolmateServer.external.aws.config.AWSConfig;
 import com.nonsoolmate.nonsoolmateServer.external.aws.error.*;
-import com.nonsoolmate.nonsoolmateServer.external.aws.service.vo.PreSignedUrlVO;
-import java.time.Duration;
-import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,12 +10,7 @@ import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
-import software.amazon.awssdk.services.s3.presigner.S3Presigner;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
-import java.net.URL;
 
 @Service
 @RequiredArgsConstructor
@@ -26,32 +19,6 @@ public class S3Service {
     @Value("${aws-property.s3-bucket-name}")
     private String bucketName;
     private final AWSConfig awsConfig;
-    private static final Long PRE_SIGNED_URL_EXPIRE_MINUTE = 1L;
-
-    public PreSignedUrlVO getUploadPreSignedUrl(final String prefix) {
-        String uuidFileName = generateZipFileName();
-        String key = prefix + uuidFileName;
-
-        S3Presigner preSigner = awsConfig.getS3Presigner();
-
-        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                .bucket(bucketName)
-                .key(key)
-                .build();
-
-        PutObjectPresignRequest preSignedUrlRequest = PutObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMinutes(PRE_SIGNED_URL_EXPIRE_MINUTE))
-                .putObjectRequest(putObjectRequest)
-                .build();
-
-        URL url = preSigner.presignPutObject(preSignedUrlRequest).url();
-
-        return PreSignedUrlVO.of(uuidFileName, url.toString());
-    }
-
-    private String generateZipFileName() {
-        return UUID.randomUUID() + ".zip";
-    }
 
     public String validateURL(final String prefix, final String fileName) {
         try {


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#139 -> dev
- closed #139


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 답안지 업로드에서 S3 PreSignedUrl 발급에서, CloudFront PreSignedUrl 발급으로 변경했습니다


## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="847" alt="스크린샷 2024-01-19 오전 5 24 00" src="https://github.com/nonsoolmate/NONSOOLMATE-SERVER/assets/81363864/d00f07cc-9da5-409d-aa77-e42912793284">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
